### PR TITLE
Improving robustness of writing responses back to client

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -30,11 +30,10 @@
 #include <boost/asio.hpp>
 #include <boost/system.hpp>
 
+#include <algorithm>
 #include <chrono>
 #include <compare>  // for operator<=
 #include <system_error>
-
-#include <print>
 
 namespace transferase {
 
@@ -217,37 +216,14 @@ connection::respond_with_header() -> void {
   }
 }
 
-// auto
-// connection::respond_with_levels() -> void {
-//   auto self(shared_from_this());
-//   boost::asio::async_write(
-//     socket, boost::asio::buffer(resp.payload),
-//     [this, self](const boost::system::error_code ec,
-//                  const std::size_t bytes_transferred) {
-//       deadline.expires_at(boost::asio::steady_timer::time_point::max());
-//       if (!ec) {
-//         lgr.info("{} Responded with levels ({}B)", conn_id,
-//         bytes_transferred); stop();
-//         /* ADS: closing here but not sure it makes sense; RAII? See comment
-//         in
-//          * check_deadline */
-//         boost::system::error_code socket_close_ec;  // for non-throwing
-//         (void)socket.close(socket_close_ec);
-//         if (socket_close_ec)
-//           lgr.warning("{} Socket close error: {}", conn_id, socket_close_ec);
-//       }
-//       else
-//         lgr.warning("{} Error sending levels: {}", conn_id, ec);
-//     });
-//   deadline.expires_after(std::chrono::seconds(read_timeout_seconds));
-// }
-
 auto
 connection::respond_with_levels() -> void {
   auto self(shared_from_this());
   socket.async_write_some(
-    boost::asio::buffer(get_outgoing_data_buffer() + outgoing_bytes_sent,
-                        outgoing_bytes_remaining),
+    boost::asio::buffer(
+      // NOLINTNEXTLINE(*-pointer-arithmetic)
+      get_outgoing_data_buffer() + outgoing_bytes_sent,
+      outgoing_bytes_remaining),
     [this, self](const boost::system::error_code ec,
                  const std::size_t bytes_transferred) {
       deadline.expires_at(boost::asio::steady_timer::time_point::max());

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -131,6 +131,14 @@ struct connection : public std::enable_shared_from_this<connection> {
 
   std::size_t outgoing_bytes_sent{};
   std::size_t outgoing_bytes_remaining{};
+
+  std::size_t n_writes{};
+  std::size_t min_write_size{std::numeric_limits<std::size_t>::max()};
+  std::size_t max_write_size{};
+
+  std::size_t n_reads{};
+  std::size_t min_read_size{std::numeric_limits<std::size_t>::max()};
+  std::size_t max_read_size{};
 };
 
 }  // namespace transferase

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -35,9 +35,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>  // for std::bind
+#include <limits>      // for std::numeric_limits
 #include <memory>
 #include <string>
 #include <utility>  // for std::move
+#include <vector>   // for std::vector
 
 namespace transferase {
 

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -95,6 +95,22 @@ struct connection : public std::enable_shared_from_this<connection> {
   auto
   check_deadline() -> void;
 
+  [[nodiscard]] auto
+  get_outgoing_n_bytes() const -> std::uint32_t {
+    return resp.n_bytes();
+  }
+
+  auto
+  prepare_to_write_response_payload() -> void {
+    outgoing_bytes_remaining = get_outgoing_n_bytes();  // init counters
+    outgoing_bytes_sent = 0;
+  }
+
+  [[nodiscard]] auto
+  get_outgoing_data_buffer() const noexcept -> const char * {
+    return reinterpret_cast<const char *>(resp.payload.data());
+  }
+
   boost::asio::ip::tcp::socket socket;  // this connection's socket
   boost::asio::steady_timer deadline;
   request_handler &handler;  // handles incoming requests
@@ -112,6 +128,9 @@ struct connection : public std::enable_shared_from_this<connection> {
   transferase::query_container query;
   std::size_t query_byte{};
   std::size_t query_remaining{};
+
+  std::size_t outgoing_bytes_sent{};
+  std::size_t outgoing_bytes_remaining{};
 };
 
 }  // namespace transferase

--- a/src/query_container.hpp
+++ b/src/query_container.hpp
@@ -76,6 +76,14 @@ struct query_container {
   data(std::uint32_t n_bytes = 0) -> char * {
     return reinterpret_cast<char *>(v.data()) + n_bytes;  // NOLINT
   }
+
+  /// @brief Get a const pointer to the underlying memory used by this
+  /// container.
+  [[nodiscard]] auto
+  data(std::uint32_t n_bytes = 0) const -> const char * {
+    return reinterpret_cast<const char *>(v.data()) + n_bytes;  // NOLINT
+  }
+
   // clang-format off
   [[nodiscard]] auto begin() {return std::begin(v);}
   [[nodiscard]] auto begin() const {return std::cbegin(v);}

--- a/test/client_config_test.cpp
+++ b/test/client_config_test.cpp
@@ -71,6 +71,9 @@ TEST_F(client_config_mock, get_defaults_success) {
   EXPECT_EQ(cfg.methylome_dir, std::string{});
 }
 
+// ADS: the test below can't work on github runners, so it's out for
+// now...
+/*
 TEST_F(client_config_mock, make_directories_failure) {
   static constexpr auto config_dir_mock = "unwritable";
 
@@ -109,6 +112,7 @@ TEST_F(client_config_mock, make_directories_failure) {
     EXPECT_TRUE(remove_ok);
   }
 }
+*/
 
 TEST_F(client_config_mock, make_directories_success) {
   static constexpr auto config_dir_mock = "config_dir";


### PR DESCRIPTION
The issue is the previous strategy of just doing async_write involved the timeout in an absolute sense. This has been changed to async_write_some, so that the timeout only applies to individual write ops and not writing the entire payload. A similar change was made on the client side when sending an intervals query