### PR TITLE
Live methylome replacement now LRU

### DIFF
--- a/src/lru_tracker.hpp
+++ b/src/lru_tracker.hpp
@@ -1,0 +1,107 @@
+/* MIT License
+ *
+ * Copyright (c) 2025 Andrew D Smith
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef SRC_LRU_TRACKER_HPP_
+#define SRC_LRU_TRACKER_HPP_
+
+#include <cassert>
+#include <cstddef>
+#include <format>
+#include <list>
+#include <string>
+#include <unordered_map>
+
+namespace transferase {
+
+template <typename T> class lru_tracker {
+public:
+  explicit lru_tracker(const std::size_t capacity) : capacity{capacity} {
+    assert(capacity > 0);
+  }
+
+  [[nodiscard]] auto
+  size() const noexcept -> std::size_t {
+    return std::size(the_map);
+  }
+
+  [[nodiscard]] auto
+  full() const noexcept -> bool {
+    return size() >= capacity;
+  }
+
+  [[nodiscard]] auto
+  back() const noexcept -> const T & {
+    return the_list.back();
+  }
+
+  [[nodiscard]] auto
+  string() const noexcept -> std::string {
+    std::string r;
+    for (const auto elem : the_list) {
+      const auto itr = the_map.find(elem);
+      const auto addr = reinterpret_cast<std::size_t>(&(*itr));  // NOLINT
+      r += std::format("{}\t{}\n", elem, addr);
+    }
+    return r;
+  }
+
+  auto
+  move_to_front(const T &s) noexcept {
+    const auto itr = the_map.find(s);
+    assert(itr != std::cend(the_map));
+
+    //// ADS: benchmark
+    // T tmp = std::move(*itr->second);
+    // the_list.erase(itr->second);
+    // the_list.emplace_front(std::move(tmp));
+
+    // delete the element from the list
+    the_list.erase(itr->second);
+    the_list.push_front(s);
+    itr->second = std::begin(the_list);
+  }
+
+  auto
+  pop() noexcept {
+    const T &s = the_list.back();
+    the_map.erase(s);
+    the_list.pop_back();
+  }
+
+  auto
+  push(const T &s) noexcept {
+    if (full())
+      pop();
+    the_list.push_front(s);
+    the_map.emplace(s, std::begin(the_list));
+  }
+
+private:
+  std::list<T> the_list;
+  std::unordered_map<T, typename std::list<T>::iterator> the_map;
+  std::size_t capacity{};
+};
+
+}  // namespace transferase
+
+#endif  // SRC_LRU_TRACKER_HPP_

--- a/src/methylome_set.cpp
+++ b/src/methylome_set.cpp
@@ -49,8 +49,11 @@ methylome_set::get_methylome(const std::string &accession, std::error_code &ec)
 
   // Easy case: methylome is already loaded
   const auto meth_itr = accession_to_methylome.find(accession);
-  if (meth_itr != std::cend(accession_to_methylome))
+  if (meth_itr != std::cend(accession_to_methylome)) {
+    // current methylome becomes the most recently used
+    accessions.move_to_front(accession);
     return meth_itr->second;
+  }
 
   // ADS: we need to load a methylome; make sure the file exists;
   // probably should check the directory in batch
@@ -67,7 +70,7 @@ methylome_set::get_methylome(const std::string &accession, std::error_code &ec)
 
   // remove loaded methylomes if we need to make room
   if (accessions.full()) {
-    const auto to_eject_itr = accession_to_methylome.find(accessions.front());
+    const auto to_eject_itr = accession_to_methylome.find(accessions.back());
     if (to_eject_itr == std::cend(accession_to_methylome)) {
       ec = methylome_error_code::error_reading_methylome;
       return nullptr;
@@ -86,7 +89,7 @@ methylome_set::get_methylome(const std::string &accession, std::error_code &ec)
 
   // ADS: if we are here, then everything went ok and we can insert
   // the accession into the ring buffer
-  accessions.push_back(accession);
+  accessions.push(accession);
 
   return insertion_result.first->second;
 }

--- a/src/methylome_set.hpp
+++ b/src/methylome_set.hpp
@@ -24,6 +24,7 @@
 #ifndef SRC_METHYLOME_SET_HPP_
 #define SRC_METHYLOME_SET_HPP_
 
+#include "lru_tracker.hpp"
 #include "ring_buffer.hpp"
 
 #include <cstdint>  // std::uint32_t
@@ -62,7 +63,7 @@ struct methylome_set {
   std::string methylome_directory;
   std::uint32_t max_live_methylomes{};
 
-  ring_buffer<std::string> accessions;
+  lru_tracker<std::string> accessions;
   std::unordered_map<std::string, std::shared_ptr<methylome>>
     accession_to_methylome;
 };

--- a/test/lru_tracker_test.cpp
+++ b/test/lru_tracker_test.cpp
@@ -1,0 +1,76 @@
+/* MIT License
+ *
+ * Copyright (c) 2025 Andrew D Smith
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <lru_tracker.hpp>
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+using namespace transferase;  // NOLINT
+
+TEST(lru_tracker_test, push_and_size) {
+  lru_tracker<std::string> tracker(3);
+  EXPECT_EQ(std::size(tracker), 0);
+  tracker.push("one");
+  EXPECT_EQ(std::size(tracker), 1);
+  tracker.push("two");
+  EXPECT_EQ(std::size(tracker), 2);
+  tracker.push("three");
+  EXPECT_EQ(std::size(tracker), 3);
+  tracker.push("four");  // This should overwrite the first element
+  EXPECT_EQ(std::size(tracker), 3);
+}
+
+TEST(lru_tracker_test, full) {
+  lru_tracker<std::string> tracker(3);
+  EXPECT_FALSE(tracker.full());
+  tracker.push("one");
+  tracker.push("two");
+  tracker.push("three");
+  EXPECT_TRUE(tracker.full());
+  tracker.push("four");
+  EXPECT_TRUE(tracker.full());
+}
+
+TEST(lru_tracker_test, front) {
+  lru_tracker<std::string> tracker(3);
+  tracker.push("one");
+  tracker.push("two");
+  tracker.push("three");
+  EXPECT_EQ(tracker.back(), "one");
+  tracker.push("four");  // This should overwrite the first element
+  EXPECT_EQ(tracker.back(), "two");
+}
+
+TEST(lru_tracker_test, move_to_front) {
+  lru_tracker<std::string> tracker(4);
+  tracker.push("one");
+  tracker.push("two");
+  tracker.push("three");
+  tracker.push("four");
+  EXPECT_EQ(tracker.back(), "one");
+  tracker.move_to_front("one");  // This should overwrite the first element
+  EXPECT_EQ(tracker.back(), "two");
+}


### PR DESCRIPTION
Added a data structure in lru_tracker.hpp; this is only for methylomes and not for genome indexes. Might be worth benchmarking before swapping to this for genome indexes