### PR TITLE
Adding unit tests for macOS

### DIFF
--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -17,7 +17,7 @@ jobs:
       run: brew update
     - name: Install dependencies
       run: |
-        brew install zlib boost
+        brew install zlib boost googletest
     - name: Configure for unit tests
       run: |
         cmake -B build \

--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -1,4 +1,4 @@
-name: Run transferase unit tests on macOS
+name: Run unit tests on macOS
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ jobs:
   macos-build:
     strategy:
       matrix:
-        os: [macos-15]
+        os: [macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -17,9 +17,7 @@ jobs:
       run: brew update
     - name: Install dependencies
       run: |
-        brew install googletest zlib boost
-    # ADS: homebrew might install libz in an "opt" dir, so specify the
-    # brew prefix and then the path to the static lib
+        brew install zlib boost
     - name: Configure for unit tests
       run: |
         cmake -B build \

--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  macos-build:
+  macos-unit-tests:
     strategy:
       matrix:
         os: [macos-13, macos-14, macos-15]

--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -29,6 +29,7 @@ jobs:
         -DCMAKE_EXE_LINKER_FLAGS="-L$(brew --prefix)/lib" \
         -DZLIB_LIBRARY=$(brew --prefix zlib)/lib/libz.a \
         -DCMAKE_CXX_COMPILER=g++-14 \
+        -DCMAKE_C_COMPILER=gcc-14 \
         -DUNIT_TESTS=on \
         -DGET_GOOGLETEST=on \
         -DCMAKE_BUILD_TYPE=Build

--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -1,0 +1,40 @@
+name: Run transferase unit tests on macOS
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  macos-build:
+    strategy:
+      matrix:
+        os: [macos-15]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Update Homebrew
+      run: brew update
+    - name: Install dependencies
+      run: |
+        brew install googletest zlib boost
+    # ADS: homebrew might install libz in an "opt" dir, so specify the
+    # brew prefix and then the path to the static lib
+    - name: Configure for unit tests
+      run: |
+        cmake -B build \
+        -DCMAKE_OSX_SYSROOT="" \
+        -DCMAKE_VERBOSE_MAKEFILE=on \
+        -DCMAKE_CXX_FLAGS="-I$(brew --prefix)/include" \
+        -DCMAKE_EXE_LINKER_FLAGS="-L$(brew --prefix)/lib" \
+        -DZLIB_LIBRARY=$(brew --prefix zlib)/lib/libz.a \
+        -DCMAKE_CXX_COMPILER=g++-14 \
+        -DUNIT_TESTS=on \
+        -DCMAKE_BUILD_TYPE=Build
+    - name: Build transferase
+      run: |
+        cmake --build build -j2
+    - name: Run the tests
+      run: |
+        ctest --test-dir build/lib --output-on-failure
+        ctest --test-dir build/cli --output-on-failure

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: Run unit tests for transferase
+name: Run unit tests on Ubuntu
 
 # Should run at 2am Pacific time
 on:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ endif()
 
 message(STATUS "Finished global compile and linker configuration")
 
-if(UNIT_TESTS)
+if(GET_GOOGLETEST)
   include(FetchContent)
   FetchContent_Declare(
     googletest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ if(GET_GOOGLETEST)
   FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG origin/main
   )
   FetchContent_MakeAvailable(googletest)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,15 @@ endif()
 
 message(STATUS "Finished global compile and linker configuration")
 
+if(UNIT_TESTS)
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+  )
+  FetchContent_MakeAvailable(googletest)
+endif()
+
 add_subdirectory(lib)
 if(BUILD_CLI)
   add_subdirectory(cli)

--- a/cmake/config_options.cmake
+++ b/cmake/config_options.cmake
@@ -35,6 +35,10 @@ option(PYTHON_TESTS "Enable Python tests" off)
 set(SANITIZER_TYPE "address"
   CACHE STRING "Choose sanitizer type (address, undefined)")
 
+if(TEST_LIB OR TEST_CLI)
+  UNIT_TESTS=on
+endif()
+
 # Release
 if(PACKAGE)
   message(STATUS "Enabling 'PACKAGE'")

--- a/cmake/config_options.cmake
+++ b/cmake/config_options.cmake
@@ -36,7 +36,7 @@ set(SANITIZER_TYPE "address"
   CACHE STRING "Choose sanitizer type (address, undefined)")
 
 if(TEST_LIB OR TEST_CLI)
-  UNIT_TESTS=on
+  set(UNIT_TESTS on)
 endif()
 
 # Release


### PR DESCRIPTION
These require g++-14 and therefore googletest from brew will not work and must be built