### PR TITLE
R API sources modified for Apple Clang

### DIFF
--- a/R/CMakeLists.txt
+++ b/R/CMakeLists.txt
@@ -206,6 +206,17 @@ set(FILES_TO_REMOVE
   "${CMAKE_INSTALL_PREFIX}/src/server.hpp"
   "${CMAKE_INSTALL_PREFIX}/src/request_handler.hpp"
   "${CMAKE_INSTALL_PREFIX}/src/request_handler.cpp"
+  "${CMAKE_INSTALL_PREFIX}/src/bins_writer.cpp"
+  "${CMAKE_INSTALL_PREFIX}/src/bins_writer.hpp"
+  "${CMAKE_INSTALL_PREFIX}/src/counts_file_format.hpp"
+  "${CMAKE_INSTALL_PREFIX}/src/counts_file_format.cpp"
+  "${CMAKE_INSTALL_PREFIX}/src/counts_file_format_impl.hpp"
+  "${CMAKE_INSTALL_PREFIX}/src/intervals_writer.hpp"
+  "${CMAKE_INSTALL_PREFIX}/src/intervals_writer.cpp"
+  "${CMAKE_INSTALL_PREFIX}/src/output_format_type.hpp"
+  "${CMAKE_INSTALL_PREFIX}/src/output_format_type.cpp"
+  "${CMAKE_INSTALL_PREFIX}/src/server_config.hpp"
+  "${CMAKE_INSTALL_PREFIX}/src/server_config.cpp"
 )
 file(REMOVE ${FILES_TO_REMOVE})
 file(REMOVE_RECURSE ${CMAKE_INSTALL_PREFIX}/src/asio/experimental)
@@ -231,7 +242,9 @@ set(EXPORTS_FILENAME ${CMAKE_INSTALL_PREFIX}/src/RcppExports.cpp)
 message(STATUS "EXPORTS_FILENAME: ${EXPORTS_FILENAME}")
 execute_process(
   COMMAND
-  sed -i -E "1s/^/\#include \"transferase_r.h\"\\n/" ${EXPORTS_FILENAME}
+  sed -i.remove "1s/^/\#include \"transferase_r.h\"\\n/" ${EXPORTS_FILENAME}
+  COMMAND
+  rm ${EXPORTS_FILENAME}.remove
   RESULT_VARIABLE EXIT_CODE
 )
 ]])

--- a/R/src/transferase_r.cpp
+++ b/R/src/transferase_r.cpp
@@ -43,6 +43,7 @@
 #include <string>
 #include <system_error>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 [[nodiscard]] static inline auto

--- a/cli/command_query.cpp
+++ b/cli/command_query.cpp
@@ -69,6 +69,7 @@ xfr query --local -d methylome_dir -x index_dir -g hg38 \
 #include "request.hpp"
 #include "request_type_code.hpp"
 #include "utilities.hpp"
+#include "query_container.hpp"
 
 #include "CLI11/CLI11.hpp"
 

--- a/cli/command_select.cpp
+++ b/cli/command_select.cpp
@@ -166,8 +166,10 @@ static inline auto
 show_selected_keys(const auto &selected_keys) {
   using std::string_literals::operator""s;
   clear();
+  // NOLINTNEXTLINE (*-type-vararg)
   mvprintw(0, 0, "Selected keys: "s);
   if (selected_keys.empty())
+    // NOLINTNEXTLINE (*-type-vararg)
     mvprintw(1, 0, "Empty selection."s);
   else {
     const auto joined = selected_keys | std::views::join_with(',') |
@@ -253,8 +255,10 @@ get_filename(std::string &filename) {
   const std::string original_filename{filename};
 
   clear();
+  // NOLINTBEGIN (*-type-vararg)
   mvprintw(0, 0, header1);
   mvprintw(1, 0, header2);
+  // NOLINTEND (*-type-vararg)
   mvprintw(2, 0, std::format(msg_fmt, filename));
   refresh();
 
@@ -276,8 +280,10 @@ get_filename(std::string &filename) {
     }
 
     clear();
+    // NOLINTBEGIN (*-type-vararg)
     mvprintw(0, 0, header1);
     mvprintw(1, 0, header2);
+    // NOLINTEND (*-type-vararg)
     mvprintw(2, 0, std::format(msg_fmt, filename));
     refresh();
   }
@@ -297,6 +303,7 @@ write_output(const auto &data, std::string &outfile) {
     confirmation = '\0';
     while (confirmation != '\0') {
       erase();
+      // NOLINTNEXTLINE (*-type-vararg)
       mvprintw(0, 0, empty_sel_msg);
       refresh();
       confirmation = std::getchar();
@@ -324,12 +331,15 @@ write_output(const auto &data, std::string &outfile) {
       erase();
       if (outfile.empty()) {
         mvprintw(0, 0, std::format(msg_fmt1_empty, std::size(data)));
+        // NOLINTNEXTLINE (*-type-vararg)
         mvprintw(1, 0, msg_fmt2_empty);
       }
       else {
         mvprintw(0, 0, std::format(msg_fmt1, std::size(data), outfile));
+        // NOLINTNEXTLINE (*-type-vararg)
         mvprintw(1, 0, msg_fmt2);
       }
+      // NOLINTNEXTLINE (*-type-vararg)
       mvprintw(2, 0, msg_fmt3);
       refresh();
       confirmation = std::getchar();
@@ -351,6 +361,7 @@ write_output(const auto &data, std::string &outfile) {
     confirmation = '\0';
     while (confirmation != '\0') {
       erase();
+      // NOLINTNEXTLINE (*-type-vararg)
       mvprintw(0, 0, done_message);
       refresh();
       confirmation = std::getchar();
@@ -368,11 +379,13 @@ confirm_quit() -> bool {
   while (std::tolower(confirmation) != 'y' &&
          std::tolower(confirmation) != 'n') {
     erase();
+    // NOLINTNEXTLINE (*-type-vararg)
     mvprintw(0, 0, message);
     refresh();
     confirmation = std::getchar();
   }
   erase();
+  // NOLINTNEXTLINE (*-type-vararg)
   mvprintw(0, 0, message);
   refresh();
   return (confirmation == 'y' || confirmation == 'Y');

--- a/docs/building.md
+++ b/docs/building.md
@@ -489,7 +489,7 @@ apt-get install -y --no-install-recommends \
     r-base-dev \
     texlive \
     texlive-fonts-extra && \
-R -e 'install.packages(c("R6", "Rcpp", "roxygen2"))' && \
+R -e "options(repos = c(CRAN = 'https://cloud.r-project.org')); install.packages(c('Rcpp', 'R6', 'roxygen2'))"
 git clone https://github.com/andrewdavidsmith/transferase && \
 cd transferase && \
 cmake -B build -DBUILD_R=on -DCMAKE_INSTALL_PREFIX=rsrc -Wno-dev && \

--- a/docs/building.md
+++ b/docs/building.md
@@ -55,7 +55,7 @@ ask for your timezone.
 Once they have installed, clone the repo:
 
 ```console
-git clone https://github.com/andrewdavidsmith/transferase
+git clone https://github.com/andrewdavidsmith/transferase && \
 cd transferase
 ```
 
@@ -155,7 +155,7 @@ apt install -y --no-install-recommends \
 Then make the venv and activate it.
 
 ```console
-python3 -m venv .venv && . .venv/bin/activate
+python3.12 -m venv .venv && . .venv/bin/activate
 ```
 
 Here are the Python packages we need and how to get them:
@@ -172,8 +172,8 @@ we set the CC env variable before the build (gcc-14 likely came along with
 g++-14, but if not, just install it):
 
 ```console
-export CC=gcc-14
-cmake -B build -DCMAKE_CXX_COMPILER=g++-14 -DPACKAGE_PYTHON=on -DCMAKE_BUILD_TYPE=Release
+export CC=gcc-14 && \
+cmake -B build -DCMAKE_CXX_COMPILER=g++-14 -DPACKAGE_PYTHON=on -DCMAKE_BUILD_TYPE=Release && \
 cmake --build build -j32
 ```
 

--- a/iwyu.json
+++ b/iwyu.json
@@ -2,5 +2,5 @@
     { "include": ["@[\"<]gtest/.*[\">]", "private", "<gtest/gtest.h>", "public"] },
     { "include": ["@[\"<]zconf.h[\">]", "private", "<zlib.h>", "public"] },
     { "include": ["@<nanobind/.*>", "private", "<nanobind/nanobind.h>", "public"] },
-    { "include": ["@[\"<]asio/.*[\">]", "private", "<asio.hpp>", "public"] },
+    { "include": ["@[\"<]asio/.*[\">]", "private", "\"asio.hpp\"", "public"] },
 ]

--- a/lib/bins_writer.cpp
+++ b/lib/bins_writer.cpp
@@ -207,6 +207,7 @@ write_bedlike_bins_impl(
   const auto write_n_cpgs = !n_cpgs.empty();
 
   std::vector<char> line(bins_writer::output_buffer_size);
+  // NOLINTNEXTLINE (*-pointer-arithmetic)
   const auto line_end = line.data() + std::size(line);
   auto error = std::errc{};
 
@@ -264,6 +265,7 @@ write_bins_dataframe_scores_impl(
   }
 
   std::vector<char> line(bins_writer::output_buffer_size);
+  // NOLINTNEXTLINE (*-pointer-arithmetic)
   const auto line_end = line.data() + std::size(line);
   auto error = std::errc{};
 
@@ -327,6 +329,7 @@ write_bins_dataframe_impl(
   }
 
   std::vector<char> line(bins_writer::output_buffer_size);
+  // NOLINTNEXTLINE (*-pointer-arithmetic)
   const auto line_end = line.data() + std::size(line);
   auto error = std::errc{};
 

--- a/lib/client_connection.hpp
+++ b/lib/client_connection.hpp
@@ -194,7 +194,7 @@ client_connection_base<D, L>::handle_resolve(
     deadline.expires_after(read_timeout_seconds);
   }
   else {
-    lgr.debug("Error resolving server: {}", ec);
+    lgr.debug("Error resolving server: {}", ec.message());
     do_finish(ec);
   }
 }
@@ -212,12 +212,12 @@ client_connection_base<D, L>::handle_connect(std::error_code ec) -> void {
       deadline.expires_after(read_timeout_seconds);
     }
     else {
-      lgr.debug("Error forming request: {}", ec);
+      lgr.debug("Error forming request: {}", ec.message());
       do_finish(ec);
     }
   }
   else {
-    lgr.debug("Error connecting: {}", ec);
+    lgr.debug("Error connecting: {}", ec.message());
     do_finish(ec);
   }
 }
@@ -235,7 +235,7 @@ client_connection_base<D, L>::handle_write_request(const std::error_code ec)
     deadline.expires_after(wait_for_work_timeout_seconds);
   }
   else {
-    lgr.debug("Error writing request: {}", ec);
+    lgr.debug("Error writing request: {}", ec.message());
     deadline.expires_after(read_timeout_seconds);
     // wait for an explanation of the problem
     asio::async_read(
@@ -263,12 +263,12 @@ client_connection_base<D, L>::handle_read_response_header(std::error_code ec)
       }
     }
     else {
-      lgr.debug("Error: {}", ec);
+      lgr.debug("Error: {}", ec.message());
       do_finish(ec);
     }
   }
   else {
-    lgr.debug("Error reading response header: {}", ec);
+    lgr.debug("Error reading response header: {}", ec.message());
     do_finish(ec);
   }
 }
@@ -292,7 +292,7 @@ client_connection_base<D, L>::do_read_response_payload() -> void {
         }
       }
       else {
-        lgr.error("Error reading levels: {}", ec);
+        lgr.error("Error reading levels: {}", ec.message());
         // exiting the read loop -- no deadline for now
         do_finish(ec);
       }
@@ -312,12 +312,12 @@ client_connection_base<D, L>::handle_failure_explanation(std::error_code ec)
       do_finish(resp_hdr.status);
     }
     else {
-      lgr.debug("Error: {}", ec);
+      lgr.debug("Error: {}", ec.message());
       do_finish(ec);
     }
   }
   else {
-    lgr.debug("Error reading response header: {}", ec);
+    lgr.debug("Error reading response header: {}", ec.message());
     do_finish(ec);
   }
 }

--- a/lib/download.cpp
+++ b/lib/download.cpp
@@ -38,6 +38,8 @@
 #include <tuple>  // IWYU pragma: keep
 #include <unordered_map>
 
+#include <ctime>
+
 namespace transferase {
 
 [[nodiscard]]
@@ -112,12 +114,20 @@ get_timestamp(const download_request &dr)
                                   dr.connect_timeout, dr.download_timeout);
   }
 
-  std::istringstream is{header.last_modified};
-  std::chrono::time_point<std::chrono::file_clock> tp;
-  if (!(is >> std::chrono::parse(http_time_format, tp)))
-    return {};
+  struct tm tm;
+  strptime(header.last_modified.data(),
+           "%a, %d %b %Y %H:%M:%S GMT", &tm);
 
-  return tp;
+  const std::time_t epoch_time = std::mktime(&tm);
+
+  return std::chrono::time_point<std::chrono::file_clock>{std::chrono::seconds(epoch_time)};
+
+  // std::istringstream is{header.last_modified};
+  // std::chrono::time_point<std::chrono::file_clock> tp;
+  // if (!(is >> std::chrono::parse(http_time_format, tp)))
+  //   return {};
+
+  // return tp;
 }
 
 }  // namespace transferase

--- a/lib/download.cpp
+++ b/lib/download.cpp
@@ -101,7 +101,7 @@ download(const download_request &dr)
 auto
 get_timestamp(const download_request &dr)
   -> std::chrono::time_point<std::chrono::file_clock> {
-  static constexpr auto http_time_format = "%a, %d %b %Y %T %z";
+  // static constexpr auto http_time_format = "%a, %d %b %Y %T %z";
 
   http_header header;
 

--- a/lib/download.cpp
+++ b/lib/download.cpp
@@ -114,7 +114,7 @@ get_timestamp(const download_request &dr)
                                   dr.connect_timeout, dr.download_timeout);
   }
 
-  struct tm tm;
+  struct tm tm{};
   strptime(header.last_modified.data(),
            "%a, %d %b %Y %H:%M:%S GMT", &tm);
 

--- a/lib/download.cpp
+++ b/lib/download.cpp
@@ -114,7 +114,9 @@ get_timestamp(const download_request &dr)
                                   dr.connect_timeout, dr.download_timeout);
   }
 
+  // clang-format off
   struct tm tm{};
+  // clang-format on
   strptime(header.last_modified.data(), "%a, %d %b %Y %H:%M:%S GMT", &tm);
 
   const std::time_t epoch_time = std::mktime(&tm);

--- a/lib/download.cpp
+++ b/lib/download.cpp
@@ -31,8 +31,8 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
-#include <print>
-#include <sstream>
+#include <print>  // IWYU pragma: keep
+#include <sstream>  // IWYU pragma: keep
 #include <string>
 #include <system_error>
 #include <tuple>  // IWYU pragma: keep

--- a/lib/download_policy.cpp
+++ b/lib/download_policy.cpp
@@ -26,7 +26,7 @@
 #include <array>
 #include <format>
 #include <iostream>
-#include <ranges>
+#include <ranges>  // IWYU pragma: keep
 #include <string>
 #include <string_view>
 #include <tuple>    // IWYU pragma: keep

--- a/lib/download_policy.cpp
+++ b/lib/download_policy.cpp
@@ -45,11 +45,15 @@ operator>>(std::istream &in, download_policy_t &dp) -> std::istream & {
   std::string tmp;
   if (!(in >> tmp))
     return in;
-  for (const auto [idx, name] : std::views::enumerate(download_policy_t_name))
+  // for (const auto [idx, name] : std::views::enumerate(download_policy_t_name))
+  std::uint32_t idx = 0;
+  for (const auto name : download_policy_t_name) {
     if (tmp == name) {
       dp = static_cast<download_policy_t>(idx);
       return in;
     }
+    ++idx;
+  }
   in.setstate(std::ios::failbit);
   return in;
 }

--- a/lib/download_policy.hpp
+++ b/lib/download_policy.hpp
@@ -56,7 +56,7 @@ static constexpr auto download_policy_t_name = std::array{
 };
 
 [[nodiscard]] inline auto
-get_download_policy_message(download_policy_t p) -> std::string {
+get_download_policy_message(const download_policy_t p) -> std::string {
   static constexpr auto download_policy_message = std::array{
     // clang-format off
     "no downloads"sv,
@@ -70,6 +70,16 @@ get_download_policy_message(download_policy_t p) -> std::string {
     return "error";
   }
   const auto &m = download_policy_message[x];
+  return std::string(std::cbegin(m), std::cend(m));
+}
+
+[[nodiscard]] inline auto
+to_string(const download_policy_t p) -> std::string {
+  const auto x = std::to_underlying(p);
+  if (x >= std::size(download_policy_t_name)) {
+    return "error";
+  }
+  const auto &m = download_policy_t_name[x];
   return std::string(std::cbegin(m), std::cend(m));
 }
 

--- a/lib/genome_index.cpp
+++ b/lib/genome_index.cpp
@@ -133,14 +133,15 @@ genome_index::parse_genome_name(
   using std::string_literals::operator""s;
   using std::literals::string_view_literals::operator""sv;
   // clang-format off
-  const auto fasta_suff = std::vector {
-    ".fa"sv,
-    ".fa.gz"sv,
-    ".faa"sv,
-    ".faa.gz"sv,
-    ".fasta"sv,
-    ".fasta.gz"sv,
-  } | std::views::join_with('|');
+  // const auto fasta_suff = std::vector {
+  //   ".fa"sv,
+  //   ".fa.gz"sv,
+  //   ".faa"sv,
+  //   ".faa.gz"sv,
+  //   ".fasta"sv,
+  //   ".fasta.gz"sv,
+  // } | std::views::join_with('|');
+  const auto fasta_suff = ".fa|.fa.gz|.faa|.faa.gz|.fasta|.fasta.gz"sv;
   // clang-format on
   const auto reference_genome_pattern =
     "("s + std::string(std::cbegin(fasta_suff), std::cend(fasta_suff)) + ")$"s;
@@ -327,8 +328,10 @@ make_genome_index_plain(const std::string &genome_filename,
 
   // init the index that maps chrom names to their rank in the order
   meta.chrom_index.clear();
-  for (const auto [i, chrom_name] : std::views::enumerate(meta.chrom_order))
-    meta.chrom_index.emplace(chrom_name, i);
+  // for (const auto [i, chrom_name] : std::views::enumerate(meta.chrom_order))
+  std::uint32_t i = 0;
+  for (const auto chrom_name : meta.chrom_order)
+    meta.chrom_index.emplace(chrom_name, i++);
 
   error = meta.init_env();
   if (error)
@@ -414,8 +417,10 @@ make_genome_index_gzip(const std::string &genome_filename,
 
   // init the index that maps chrom names to their rank in the order
   meta.chrom_index.clear();
-  for (const auto [i, chrom_name] : std::views::enumerate(meta.chrom_order))
-    meta.chrom_index.emplace(chrom_name, i);
+  // for (const auto [i, chrom_name] : std::views::enumerate(meta.chrom_order))
+  std::uint32_t i = 0;
+  for (const auto chrom_name : meta.chrom_order)
+    meta.chrom_index.emplace(chrom_name, i++);
 
   error = meta.init_env();
   if (error)

--- a/lib/genome_index.cpp
+++ b/lib/genome_index.cpp
@@ -330,7 +330,7 @@ make_genome_index_plain(const std::string &genome_filename,
   meta.chrom_index.clear();
   // for (const auto [i, chrom_name] : std::views::enumerate(meta.chrom_order))
   std::uint32_t i = 0;
-  for (const auto chrom_name : meta.chrom_order)
+  for (const auto &chrom_name : meta.chrom_order)
     meta.chrom_index.emplace(chrom_name, i++);
 
   error = meta.init_env();
@@ -419,7 +419,7 @@ make_genome_index_gzip(const std::string &genome_filename,
   meta.chrom_index.clear();
   // for (const auto [i, chrom_name] : std::views::enumerate(meta.chrom_order))
   std::uint32_t i = 0;
-  for (const auto chrom_name : meta.chrom_order)
+  for (const auto &chrom_name : meta.chrom_order)
     meta.chrom_index.emplace(chrom_name, i++);
 
   error = meta.init_env();

--- a/lib/genome_index.hpp
+++ b/lib/genome_index.hpp
@@ -95,7 +95,7 @@ struct genome_index {
   /// @brief Generate a string representation in JSON format for a genome_index
   [[nodiscard]] auto
   tostring() const noexcept -> std::string {
-    return std::format(R"json({{"meta": {}, "data": {}}})json", meta, data);
+    return std::format(R"json({{"meta": {}, "data": {}}})json", meta.tostring(), data.tostring());
   }
 
   /// @brief Get a const reference to the associated metadata

--- a/lib/genome_index_data.cpp
+++ b/lib/genome_index_data.cpp
@@ -129,7 +129,9 @@ make_query_within_chrom(const genome_index_data::vec &positions,
   -> transferase::query_container {
   transferase::query_container query(std::size(chrom_ranges));
   auto cursor = std::cbegin(positions);
-  for (const auto [idx, cr] : std::views::enumerate(chrom_ranges)) {
+  // for (const auto [idx, cr] : std::views::enumerate(chrom_ranges)) {
+  std::uint32_t idx = 0;
+  for (const auto cr : chrom_ranges) {
     namespace rg = std::ranges;
     cursor = rg::lower_bound(cursor, std::cend(positions), cr.start);
     const auto pos_stop =
@@ -138,6 +140,7 @@ make_query_within_chrom(const genome_index_data::vec &positions,
       static_cast<q_elem_t>(rg::distance(std::cbegin(positions), cursor)),
       static_cast<q_elem_t>(rg::distance(std::cbegin(positions), pos_stop)),
     };
+    ++idx;
   }
   return query;
 }

--- a/lib/intervals_writer.cpp
+++ b/lib/intervals_writer.cpp
@@ -209,6 +209,7 @@ write_bedlike_intervals_impl(
 
   std::vector<char> line(intervals_writer::output_buffer_size);
   auto line_beg = line.data();
+  // NOLINTNEXTLINE (*-pointer-arithmetic)
   const auto line_end = line.data() + std::size(line);
   auto error = std::errc{};
 
@@ -274,6 +275,7 @@ write_intervals_dataframe_scores_impl(
 
   std::vector<char> line(intervals_writer::output_buffer_size);
   auto line_beg = line.data();
+  // NOLINTNEXTLINE (*-pointer-arithmetic)
   const auto line_end = line.data() + std::size(line);
   auto error = std::errc{};
 
@@ -338,6 +340,7 @@ write_intervals_dataframe_impl(
 
   std::vector<char> line(intervals_writer::output_buffer_size);
   auto line_beg = line.data();
+  // NOLINTNEXTLINE (*-pointer-arithmetic)
   const auto line_end = line.data() + std::size(line);
   auto error = std::errc{};
 

--- a/lib/level_element_formatter.hpp
+++ b/lib/level_element_formatter.hpp
@@ -24,6 +24,8 @@
 #ifndef LIB_LEVEL_ELEMENT_FORMATTER_HPP_
 #define LIB_LEVEL_ELEMENT_FORMATTER_HPP_
 
+#include "level_element.hpp"
+
 #include <charconv>
 #include <cstdint>
 #include <format>

--- a/lib/logger.hpp
+++ b/lib/logger.hpp
@@ -122,11 +122,15 @@ operator>>(std::istream &in, log_level_t &l) -> std::istream & {
   std::string tmp;
   if (!(in >> tmp))
     return in;
-  for (const auto [idx, name] : std::views::enumerate(level_name))
+  // for (const auto [idx, name] : std::views::enumerate(level_name))
+  std::uint32_t idx = 0;
+  for (const auto name : level_name) {
     if (tmp == name) {
       l = static_cast<log_level_t>(idx);
       return in;
     }
+    ++idx;
+  }
   in.setstate(std::ios::failbit);
   return in;
 }

--- a/lib/methylome_data.cpp
+++ b/lib/methylome_data.cpp
@@ -229,11 +229,8 @@ methylome_data::get_levels<level_element_t>(
   -> void {
   const auto beg = std::cbegin(cpgs);
   // for (const auto [i, q] : std::views::enumerate(query))
-  std::uint32_t i = 0;
-  for (const auto q : query) {
+  for (const auto q : query)
     *d_first++ = get_levels_impl<level_element_t>(beg + q.start, beg + q.stop);
-    ++i;
-  }
 }
 
 template <>
@@ -259,12 +256,9 @@ methylome_data::get_levels<level_element_covered_t>(
   const noexcept -> void {
   const auto beg = std::cbegin(cpgs);
   // for (const auto [i, q] : std::views::enumerate(query))
-  std::uint32_t i = 0;
-  for (const auto q : query) {
+  for (const auto q : query)
     *d_first++ =
       get_levels_impl<level_element_covered_t>(beg + q.start, beg + q.stop);
-    ++i;
-  }
 }
 
 template <>

--- a/lib/methylome_data.cpp
+++ b/lib/methylome_data.cpp
@@ -32,6 +32,7 @@
 #include "methylome_metadata.hpp"
 #include "query_container.hpp"
 #include "zlib_adapter.hpp"
+#include "query_element.hpp"  // implicitly used
 
 #include <algorithm>
 #include <cassert>

--- a/lib/methylome_data.cpp
+++ b/lib/methylome_data.cpp
@@ -214,8 +214,10 @@ methylome_data::get_levels<level_element_t>(
   -> level_container_md<level_element_t> {
   std::vector<level_element_t> res(std::size(query));
   const auto beg = std::cbegin(cpgs);
-  for (const auto [i, q] : std::views::enumerate(query))
-    res[i] = get_levels_impl<level_element_t>(beg + q.start, beg + q.stop);
+  // for (const auto [i, q] : std::views::enumerate(query))
+  std::uint32_t i = 0;
+  for (const auto q : query)
+    res[i++] = get_levels_impl<level_element_t>(beg + q.start, beg + q.stop);
   return level_container_md<level_element_t>(std::move(res));
 }
 
@@ -226,8 +228,12 @@ methylome_data::get_levels<level_element_t>(
   level_container_md<level_element_t>::iterator d_first) const noexcept
   -> void {
   const auto beg = std::cbegin(cpgs);
-  for (const auto [i, q] : std::views::enumerate(query))
+  // for (const auto [i, q] : std::views::enumerate(query))
+  std::uint32_t i = 0;
+  for (const auto q : query) {
     *d_first++ = get_levels_impl<level_element_t>(beg + q.start, beg + q.stop);
+    ++i;
+  }
 }
 
 template <>
@@ -237,8 +243,10 @@ methylome_data::get_levels<level_element_covered_t>(
   -> level_container_md<level_element_covered_t> {
   std::vector<level_element_covered_t> res(std::size(query));
   const auto beg = std::cbegin(cpgs);
-  for (const auto [i, q] : std::views::enumerate(query))
-    res[i] =
+  // for (const auto [i, q] : std::views::enumerate(query))
+  std::uint32_t i = 0;
+  for (const auto q : query)
+    res[i++] =
       get_levels_impl<level_element_covered_t>(beg + q.start, beg + q.stop);
   return level_container_md<level_element_covered_t>(std::move(res));
 }
@@ -250,9 +258,13 @@ methylome_data::get_levels<level_element_covered_t>(
   typename level_container_md<level_element_covered_t>::iterator d_first)
   const noexcept -> void {
   const auto beg = std::cbegin(cpgs);
-  for (const auto [i, q] : std::views::enumerate(query))
+  // for (const auto [i, q] : std::views::enumerate(query))
+  std::uint32_t i = 0;
+  for (const auto q : query) {
     *d_first++ =
       get_levels_impl<level_element_covered_t>(beg + q.start, beg + q.stop);
+    ++i;
+  }
 }
 
 template <>

--- a/lib/request.cpp
+++ b/lib/request.cpp
@@ -43,7 +43,7 @@ std::uint32_t request::min_bin_size = request::min_bin_size_default;
 [[nodiscard]] STATIC INLINE auto
 compose(char *first, char const *last, const request &req) -> std::error_code {
   // ADS: use to_chars here
-  const std::string s = std::format("{}\n", req);
+  const std::string s = std::format("{}\n", req.tostring());
   if (std::size(s) >= request_buffer_size)
     return request_error_code::request_too_large;
 
@@ -139,15 +139,18 @@ parse(const request_buffer &buf, request &req) -> std::error_code {
 
 [[nodiscard]] auto
 request::summary() const -> std::string {
-  auto joined = methylome_names | std::views::transform([](const auto &r) {
-                  return std::format("\"{}\"", r);
-                }) |
-                std::views::join_with(',') | std::ranges::to<std::string>();
+  // auto joined = methylome_names | std::views::transform([](const auto &r) {
+  //                 return std::format("\"{}\"", r);
+  //               }) |
+  //               std::views::join_with(',') | std::ranges::to<std::string>();
+  std::string joined = std::format("\"{}\"", methylome_names.front());
+  for (auto i = 1u; i < std::size(methylome_names); ++i)
+    joined += std::format(",\"{}\"", methylome_names[i]);
   return std::format(R"({{"request_type": {}, )"
                      R"("index_hash": {}, )"
                      R"("aux_value": {}, )"
                      R"("methylome_names": [{}]}})",
-                     request_type, index_hash, aux_value, joined);
+                     to_string(request_type), index_hash, aux_value, joined);
 }
 
 }  // namespace transferase

--- a/lib/request.hpp
+++ b/lib/request.hpp
@@ -109,7 +109,7 @@ struct request {
                      index_hash, aux_value);
     for (const auto &methylome_name : methylome_names)
       s += std::format("\t{}", methylome_name);
-    return s;
+    return std::format("{}\n", s);
   }
 };
 

--- a/lib/request.hpp
+++ b/lib/request.hpp
@@ -101,6 +101,16 @@ struct request {
     return request_type == request_type_code::intervals_covered ||
            request_type == request_type_code::bins_covered;
   }
+
+  [[nodiscard]] auto
+  tostring() const -> std::string {
+    std::string s;
+    s += std::format("{}\t{}\t{}", to_string(request_type),
+                     index_hash, aux_value);
+    for (const auto &methylome_name : methylome_names)
+      s += std::format("\t{}", methylome_name);
+    return s;
+  }
 };
 
 [[nodiscard]] auto
@@ -116,7 +126,7 @@ struct std::formatter<transferase::request> : std::formatter<std::string> {
   auto
   format(const transferase::request &r, std::format_context &ctx) const {
     std::string s;
-    s += std::format("{}\t{}\t{}", r.request_type, r.index_hash, r.aux_value);
+    s += std::format("{}\t{}\t{}", to_string(r.request_type), r.index_hash, r.aux_value);
     for (const auto &methylome_name : r.methylome_names)
       s += std::format("\t{}", methylome_name);
     return std::format_to(ctx.out(), "{}\n", s);

--- a/lib/request_type_code.hpp
+++ b/lib/request_type_code.hpp
@@ -28,6 +28,8 @@
 #include <cstdint>  // for std::uint32_t
 #include <format>
 #include <string>
+#include <iterator>
+#include <string_view>
 #include <utility>  // for to_underlying, unreachable
 
 namespace transferase {
@@ -41,15 +43,26 @@ enum class request_type_code : std::uint8_t {
   n_request_types = 5,
 };
 
+using std::literals::string_view_literals::operator""sv;
 static constexpr auto request_type_code_names = std::array{
   // clang-format off
-  "intervals",
-  "intervals_covered",
-  "bins",
-  "bins_covered",
-  "unknown",
+  "intervals"sv,
+  "intervals_covered"sv,
+  "bins"sv,
+  "bins_covered"sv,
+  "unknown"sv,
   // clang-format on
 };
+
+[[nodiscard]] inline auto
+to_string(const request_type_code c) -> std::string {
+  const auto x = std::to_underlying(c);
+  if (x >= std::size(request_type_code_names)) {
+    return "error";
+  }
+  const auto &m = request_type_code_names[x];
+  return std::string(std::cbegin(m), std::cend(m));
+}
 
 }  // namespace transferase
 

--- a/lib/request_type_code.hpp
+++ b/lib/request_type_code.hpp
@@ -29,7 +29,6 @@
 #include <format>
 #include <string>
 #include <iterator>
-#include <string_view>
 #include <utility>  // for to_underlying, unreachable
 
 namespace transferase {
@@ -43,25 +42,19 @@ enum class request_type_code : std::uint8_t {
   n_request_types = 5,
 };
 
-using std::literals::string_view_literals::operator""sv;
 static constexpr auto request_type_code_names = std::array{
   // clang-format off
-  "intervals"sv,
-  "intervals_covered"sv,
-  "bins"sv,
-  "bins_covered"sv,
-  "unknown"sv,
+  "intervals",
+  "intervals_covered",
+  "bins",
+  "bins_covered",
+  "unknown",
   // clang-format on
 };
 
 [[nodiscard]] inline auto
 to_string(const request_type_code c) -> std::string {
-  const auto x = std::to_underlying(c);
-  if (x >= std::size(request_type_code_names)) {
-    return "error";
-  }
-  const auto &m = request_type_code_names[x];
-  return std::string(std::cbegin(m), std::cend(m));
+  return std::format("{}", std::to_underlying(c));
 }
 
 }  // namespace transferase

--- a/lib/server.hpp
+++ b/lib/server.hpp
@@ -25,7 +25,6 @@
 #define LIB_SERVER_HPP_
 
 #include "request_handler.hpp"
-#include "server_error_code.hpp"
 
 #include "asio.hpp"
 
@@ -33,8 +32,6 @@
 #include <cstdint>
 #include <string>
 #include <system_error>
-#include <type_traits>
-#include <utility>
 
 namespace transferase {
 

--- a/lib/tests/request_handler_test.cpp
+++ b/lib/tests/request_handler_test.cpp
@@ -31,9 +31,9 @@
 #include <query_element.hpp>
 #include <request.hpp>
 #include <request_type_code.hpp>
-#include <server_error_code.hpp>
 #include <response.hpp>
 #include <server.hpp>
+#include <server_error_code.hpp>
 
 #include <gtest/gtest.h>
 

--- a/lib/tests/request_test.cpp
+++ b/lib/tests/request_test.cpp
@@ -52,7 +52,7 @@ TEST(request_test, valid_compose) {
   EXPECT_FALSE(compose_ec);
   request req_parsed;
   const std::error_code parse_ec = parse(buf, req_parsed);
-  EXPECT_FALSE(parse_ec);
+  EXPECT_FALSE(parse_ec) << parse_ec.message();
   EXPECT_EQ(req, req_parsed);
   EXPECT_EQ(req_parsed.n_intervals(), mock_aux_value);
 }

--- a/lib/utilities.cpp
+++ b/lib/utilities.cpp
@@ -58,13 +58,13 @@ validate_output_directory(const std::string &dirname,
   auto &lgr = transferase::logger::instance();
   const bool dir_exists = std::filesystem::exists(dirname, error);
   if (error) {
-    lgr.error("Filesystem error {}: {}", dirname, error);
+    lgr.error("Filesystem error {}: {}", dirname, error.message());
     return;
   }
   if (!dir_exists) {
     const bool dirs_ok = std::filesystem::create_directories(dirname, error);
     if (error) {
-      lgr.error("Failed to create directory {}: {}", dirname, error);
+      lgr.error("Failed to create directory {}: {}", dirname, error.message());
       return;
     }
     const auto status = dirs_ok ? "created" : "exists";

--- a/lib/utilities.hpp
+++ b/lib/utilities.hpp
@@ -72,7 +72,10 @@ rlstrip(const std::string &s) noexcept -> std::string {
     return std::isgraph(c);
   };
   const auto start = std::ranges::find_if(s, is_graph);
-  auto stop = std::begin(std::ranges::find_last_if(s, is_graph));
+  // auto stop = std::begin(std::ranges::find_last_if(s, is_graph));
+  auto stop = std::end(s);
+  while (stop != std::cbegin(s) && !is_graph(*(--stop)))
+    ;
   if (stop != std::cend(s))
     ++stop;
   return std::string(start, stop);


### PR DESCRIPTION
This is because R, even when installed through conda, on Apple Silicon will use the Apple Clang compiler and there really isn't a good way to get g++ working well with it. This is important for R, since it will be built from source and not distributable as a pre-built binary