### PR TITLE
Rewrites for AppleClang 16

### DIFF
--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -21,11 +21,12 @@ jobs:
     - name: Configure for unit tests
       run: |
         cmake -B build \
+        -DCMAKE_VERBOSE_MAKEFILE=on \
         -DCMAKE_CXX_FLAGS="-I$(brew --prefix)/include" \
         -DCMAKE_EXE_LINKER_FLAGS="-L$(brew --prefix)/lib" \
         -DZLIB_LIBRARY=$(brew --prefix zlib)/lib/libz.a \
-        -DCMAKE_CXX_COMPILER=g++ \
-        -DCMAKE_C_COMPILER=gcc \
+        -DCMAKE_CXX_COMPILER=clang++ \
+        -DCMAKE_C_COMPILER=clang \
         -DUNIT_TESTS=on \
         -DGET_GOOGLETEST=on \
         -DCMAKE_BUILD_TYPE=Build

--- a/.github/workflows/macos-unit-tests.yml
+++ b/.github/workflows/macos-unit-tests.yml
@@ -24,8 +24,8 @@ jobs:
         -DCMAKE_CXX_FLAGS="-I$(brew --prefix)/include" \
         -DCMAKE_EXE_LINKER_FLAGS="-L$(brew --prefix)/lib" \
         -DZLIB_LIBRARY=$(brew --prefix zlib)/lib/libz.a \
-        -DCMAKE_CXX_COMPILER=g++-14 \
-        -DCMAKE_C_COMPILER=gcc-14 \
+        -DCMAKE_CXX_COMPILER=g++ \
+        -DCMAKE_C_COMPILER=gcc \
         -DUNIT_TESTS=on \
         -DGET_GOOGLETEST=on \
         -DCMAKE_BUILD_TYPE=Build

--- a/cli/command_check.cpp
+++ b/cli/command_check.cpp
@@ -54,6 +54,8 @@ xfr check -x index_dir -d methylome_dir
 #include "methylome_set.hpp"
 #include "utilities.hpp"
 
+#include "macos_helper.hpp"
+
 #include "CLI11/CLI11.hpp"
 
 #include <cstdlib>  // for EXIT_FAILURE, EXIT_SUCCESS
@@ -154,8 +156,8 @@ command_check_main(int argc, char *argv[]) -> int {  // NOLINT(*-c-arrays)
   else
     genome_names = {genome_name_arg};
 
-  const auto joined_methylomes = methylome_names | std::views::join_with(',');
-  const auto joined_genomes = genome_names | std::views::join_with(',');
+  const auto joined_methylomes = join_with(methylome_names, ',');
+  const auto joined_genomes = join_with(genome_names, ',');
   const std::vector<std::tuple<std::string, std::string>> args_to_log{
     // clang-format off
     {"Index directory", index_dir},

--- a/cli/command_config.cpp
+++ b/cli/command_config.cpp
@@ -57,6 +57,8 @@ xfr config --update -s localhost -p 5000
 #include "logger.hpp"
 #include "utilities.hpp"
 
+#include "macos_helper.hpp"
+
 #include "CLI11/CLI11.hpp"
 
 #include <cstdlib>
@@ -201,8 +203,9 @@ command_config_main(int argc, char *argv[]) -> int {  // NOLINT(*-c-arrays)
     cfg.assign_defaults_to_missing(empty_sys_config_dir, error);
   }
 
-  const auto genomes_joined =
-    genomes | std::views::join_with(',') | std::ranges::to<std::string>();
+  // const auto genomes_joined =
+  //   genomes | std::views::join_with(',') | std::ranges::to<std::string>();
+  const auto genomes_joined = join_with(genomes, ',');
 
   using std::string_literals::operator""s;
   constexpr auto or_none = [](const auto &s) {

--- a/cli/command_list.cpp
+++ b/cli/command_list.cpp
@@ -131,7 +131,7 @@ command_list_main(int argc, char *argv[])  // NOLINT(*-c-arrays)
       }
       std::ranges::for_each(index_names, print);
       if (verbose && !show_only_indexes)
-        std::println();
+        std::print("\n");
     }
     if (!show_only_indexes) {
       if (verbose && !show_only_methylomes)
@@ -143,7 +143,7 @@ command_list_main(int argc, char *argv[])  // NOLINT(*-c-arrays)
       }
       std::ranges::for_each(methylome_names, print);
       if (verbose && !show_only_methylomes)
-        std::println();
+        std::print("\n");
     }
   }
 

--- a/cli/command_merge.cpp
+++ b/cli/command_merge.cpp
@@ -136,8 +136,12 @@ command_merge_main(int argc, char *argv[]) -> int {  // NOLINT(*-c-arrays)
   xfr::log_args<xfr::log_level_t::info>(args_to_log);
 
   std::vector<std::tuple<std::string, std::string>> filenames_to_log;
-  for (const auto [i, filename] : std::views::enumerate(methylome_names))
+  // for (const auto [i, filename] : std::views::enumerate(methylome_names))
+  std::uint32_t i = 0;
+  for (const auto &filename : methylome_names) {
     filenames_to_log.emplace_back(std::format("Methylome{}", i), filename);
+    ++i;
+  }
   xfr::log_args<xfr::log_level_t::debug>(filenames_to_log);
 
   std::error_code error;

--- a/cli/command_query.cpp
+++ b/cli/command_query.cpp
@@ -71,6 +71,8 @@ xfr query --local -d methylome_dir -x index_dir -g hg38 \
 #include "request_type_code.hpp"
 #include "utilities.hpp"
 
+#include "macos_helper.hpp"
+
 #include "CLI11/CLI11.hpp"
 
 #include <asio.hpp>
@@ -99,8 +101,9 @@ xfr query --local -d methylome_dir -x index_dir -g hg38 \
 format_methylome_names_brief(const std::vector<std::string> &names)
   -> std::string {
   static constexpr auto max_names_width = 50;
-  auto joined =
-    names | std::views::join_with(' ') | std::ranges::to<std::string>();
+  // auto joined =
+  //   names | std::views::join_with(' ') | std::ranges::to<std::string>();
+  auto joined = join_with(names, ' ');
   if (std::size(joined) > max_names_width)
     return std::format("{}...{} ({} methylomes)", names.front(), names.back(),
                        std::size(names));

--- a/cli/command_select.cpp
+++ b/cli/command_select.cpp
@@ -61,6 +61,8 @@ command_select_main([[maybe_unused]] int argc,
 #include "nlohmann/json.hpp"
 #include "utilities.hpp"
 
+#include "macos_helper.hpp"
+
 #include "CLI11/CLI11.hpp"
 
 #include <ncurses.h>
@@ -90,6 +92,8 @@ command_select_main([[maybe_unused]] int argc,
 #include <unordered_set>
 #include <utility>  // for std::pair
 #include <vector>
+
+namespace xfr = transferase;
 
 [[nodiscard]] auto
 load_data(const std::string &json_filename, std::error_code &error)
@@ -171,8 +175,9 @@ show_selected_keys(const auto &selected_keys) {
   if (selected_keys.empty())
     mvprintw(1, 0, "Empty selection."s);  // NOLINT (*-type-vararg)
   else {
-    const auto joined = selected_keys | std::views::join_with(',') |
-                        std::ranges::to<std::string>();
+    // const auto joined = selected_keys | std::views::join_with(',') |
+    //                     std::ranges::to<std::string>();
+    const auto joined = join_with(selected_keys, ',');
     mvprintw(1, 0, joined);
   }
   refresh();
@@ -479,7 +484,9 @@ main_loop(const std::vector<std::pair<std::string, std::string>> &data,
     erase();  // performs better than using clear();
     mvprintw(0, 0, current_legend);
 
-    for (const auto [idx, entry] : std::views::enumerate(to_show)) {
+    // for (const auto [idx, entry] : std::views::enumerate(to_show)) {
+    std::int32_t idx = 0;  // ADS: need to compare with signed cursor_pos
+    for (const auto &entry : to_show) {
       // Calculate the global data index
       const auto data_idx = disp_start + idx;
       const auto y_pos = static_cast<std::int32_t>(idx + legend_height);
@@ -505,6 +512,7 @@ main_loop(const std::vector<std::pair<std::string, std::string>> &data,
       attroff(COLOR_PAIR(2));
       attroff(COLOR_PAIR(3));
       attroff(COLOR_PAIR(4));
+      ++idx;
     }
     refresh();
 

--- a/cli/transferase.cpp
+++ b/cli/transferase.cpp
@@ -73,8 +73,13 @@ static auto
 format_help(const std::string &description,
             std::ranges::input_range auto &&cmds) {
   static constexpr auto sep_width = 4;
-  const auto cmds_comma =
-    cmds | std::views::elements<0> | std::views::join_with(',');
+  // const auto cmds_comma =
+  //   cmds | std::views::elements<0> | std::views::join_with(',');
+
+  auto cmds_comma = std::string(std::get<0>(cmds.front()));
+  for (auto i = 1u; i < std::size(cmds); ++i)
+    cmds_comma += std::format(",{}", std::get<0>(cmds[i]));
+
   const std::string cmds_line(std::cbegin(cmds_comma), std::cend(cmds_comma));
   std::println("usage: {} {{{}}}\n\n"
                "version: {}\n",
@@ -85,7 +90,8 @@ format_help(const std::string &description,
   const auto sz = std::ranges::max(std::views::transform(
     cmds | std::views::elements<0>, &std::string_view::size));
   std::ranges::for_each(cmds, [sz, w = sep_width](const auto &cmd) {
-    std::println("    {:{}}{}", get<0>(cmd), sz + w, get<2>(cmd));
+    std::println("    {:{}}{}", std::get<0>(cmd), sz + w, std::get<2>(cmd));
+    // std::println("    {:{}}{}", get<0>(cmd), sz + w, get<2>(cmd));
   });
 }
 

--- a/lib/bins_writer.cpp
+++ b/lib/bins_writer.cpp
@@ -30,6 +30,8 @@
 #include "level_element.hpp"
 #include "level_element_formatter.hpp"
 
+#include "macos_helper.hpp"
+
 #include <algorithm>  // std::min
 #include <cerrno>
 #include <cstdint>  // for std::uint32_t
@@ -79,7 +81,7 @@ write_bedlike_bins_impl(const std::string &outfile,
         std::print(out, "{}{}", delim, lvl_to_string(levels[j][i]));
       if (write_n_cpgs)
         std::print(out, "{}{}", delim, n_cpgs[i]);
-      std::println(out);
+      std::print(out, "\n");
       ++i;
     }
   }
@@ -106,8 +108,9 @@ write_bins_dfscores_impl(const std::string &outfile,
   const auto write_n_cpgs = !n_cpgs.empty();
 
   if (write_header) {
-    auto joined =
-      names | std::views::join_with(delim) | std::ranges::to<std::string>();
+    // auto joined =
+    //   names | std::views::join_with(delim) | std::ranges::to<std::string>();
+    auto joined = join_with(names, delim);
     if (write_n_cpgs)
       joined += std::format("{}{}", delim, "N_CPG"sv);
     std::println(out, "{}", joined);
@@ -126,7 +129,7 @@ write_bins_dfscores_impl(const std::string &outfile,
           std::print(out, "{}{:.6}", delim, levels[j][i].get_wmean());
         else
           std::print(out, "{}{}", delim, none_label);
-      std::println(out);
+      std::println(out, "\n");
       ++i;
     }
   }
@@ -147,10 +150,10 @@ write_bins_dataframe_impl(const std::string &outfile,
   // determine type
   using outer_type = typename std::remove_cvref_t<decltype(levels)>::value_type;
   using level_element = typename std::remove_cvref_t<outer_type>::value_type;
-  const auto hdr_formatter = [mode](const auto &r) {
+  const auto hdr_formatter = [&](const auto &r) {
     return mode == level_element_mode::classic
-             ? std::format(level_element::hdr_fmt_cls, r, delim, r, delim, r)
-             : std::format(level_element::hdr_fmt, r, delim, r, delim, r);
+      ? std::format(level_element::hdr_fmt_cls, r, delim, r, delim, r)
+      : std::format(level_element::hdr_fmt, r, delim, r, delim, r);
   };
   const auto lvl_to_string = [mode](const auto &l) {
     return mode == level_element_mode::classic ? l.tostring_classic()
@@ -164,8 +167,9 @@ write_bins_dataframe_impl(const std::string &outfile,
   const auto write_n_cpgs = !n_cpgs.empty();
 
   if (write_header) {
-    auto joined = names | std::views::transform(hdr_formatter) |
-                  std::views::join_with(delim) | std::ranges::to<std::string>();
+    // auto joined = names | std::views::transform(hdr_formatter) |
+    //               std::views::join_with(delim) | std::ranges::to<std::string>();
+    auto joined = join_with(names | std::views::transform(hdr_formatter), delim);
     if (write_n_cpgs)
       joined += std::format("{}{}", delim, "N_CPG"sv);
     std::println(out, "{}", joined);
@@ -183,7 +187,7 @@ write_bins_dataframe_impl(const std::string &outfile,
         std::print(out, "{}{}", delim, lvl_to_string(levels[j][i]));
       if (write_n_cpgs)
         std::print(out, "{}{}", delim, n_cpgs[i]);
-      std::println(out);
+      std::println(out, "\n");
       ++i;
     }
 
@@ -265,8 +269,9 @@ write_bins_dfscores_impl(
   const auto write_n_cpgs = !n_cpgs.empty();
 
   if (write_header) {
-    auto joined =
-      names | std::views::join_with(delim) | std::ranges::to<std::string>();
+    // auto joined =
+    //   names | std::views::join_with(delim) | std::ranges::to<std::string>();
+    auto joined = join_with(names, delim);
     if (write_n_cpgs)
       joined += std::format("{}{}", delim, "N_CPG");
     std::println(out, "{}", joined);
@@ -319,7 +324,7 @@ write_bins_dataframe_impl(
   static constexpr auto delim{'\t'};
   static constexpr auto newline{'\n'};
 
-  const auto hdr_formatter = [mode](const auto &r) {
+  const auto hdr_formatter = [&](const auto &r) {
     return mode == level_element_mode::classic
              ? std::format(level_element::hdr_fmt_cls, r, delim, r, delim, r)
              : std::format(level_element::hdr_fmt, r, delim, r, delim, r);
@@ -332,8 +337,9 @@ write_bins_dataframe_impl(
   const auto write_n_cpgs = !n_cpgs.empty();
 
   if (write_header) {
-    auto joined = names | std::views::transform(hdr_formatter) |
-                  std::views::join_with(delim) | std::ranges::to<std::string>();
+    // auto joined = names | std::views::transform(hdr_formatter) |
+    //               std::views::join_with(delim) | std::ranges::to<std::string>();
+    auto joined = join_with(names | std::views::transform(hdr_formatter), delim);
     if (write_n_cpgs)
       joined += std::format("{}{}", delim, "N_CPG");
     std::println(out, "{}", joined);

--- a/lib/bins_writer.cpp
+++ b/lib/bins_writer.cpp
@@ -81,6 +81,7 @@ write_bedlike_bins_impl(const std::string &outfile,
         std::print(out, "{}{}", delim, lvl_to_string(levels[j][i]));
       if (write_n_cpgs)
         std::print(out, "{}{}", delim, n_cpgs[i]);
+      // std::println(out);
       std::print(out, "\n");
       ++i;
     }
@@ -129,7 +130,8 @@ write_bins_dfscores_impl(const std::string &outfile,
           std::print(out, "{}{:.6}", delim, levels[j][i].get_wmean());
         else
           std::print(out, "{}{}", delim, none_label);
-      std::println(out, "\n");
+      // std::println(out);
+      std::print(out, "\n");
       ++i;
     }
   }
@@ -187,7 +189,8 @@ write_bins_dataframe_impl(const std::string &outfile,
         std::print(out, "{}{}", delim, lvl_to_string(levels[j][i]));
       if (write_n_cpgs)
         std::print(out, "{}{}", delim, n_cpgs[i]);
-      std::println(out, "\n");
+      // std::println(out);
+      std::print(out, "\n");
       ++i;
     }
 

--- a/lib/bins_writer.cpp
+++ b/lib/bins_writer.cpp
@@ -154,8 +154,8 @@ write_bins_dataframe_impl(const std::string &outfile,
   using level_element = typename std::remove_cvref_t<outer_type>::value_type;
   const auto hdr_formatter = [&](const auto &r) {
     return mode == level_element_mode::classic
-      ? std::format(level_element::hdr_fmt_cls, r, delim, r, delim, r)
-      : std::format(level_element::hdr_fmt, r, delim, r, delim, r);
+             ? std::format(level_element::hdr_fmt_cls, r, delim, r, delim, r)
+             : std::format(level_element::hdr_fmt, r, delim, r, delim, r);
   };
   const auto lvl_to_string = [mode](const auto &l) {
     return mode == level_element_mode::classic ? l.tostring_classic()
@@ -170,8 +170,10 @@ write_bins_dataframe_impl(const std::string &outfile,
 
   if (write_header) {
     // auto joined = names | std::views::transform(hdr_formatter) |
-    //               std::views::join_with(delim) | std::ranges::to<std::string>();
-    auto joined = join_with(names | std::views::transform(hdr_formatter), delim);
+    //               std::views::join_with(delim) |
+    //               std::ranges::to<std::string>();
+    auto joined =
+      join_with(names | std::views::transform(hdr_formatter), delim);
     if (write_n_cpgs)
       joined += std::format("{}{}", delim, "N_CPG"sv);
     std::println(out, "{}", joined);
@@ -341,8 +343,10 @@ write_bins_dataframe_impl(
 
   if (write_header) {
     // auto joined = names | std::views::transform(hdr_formatter) |
-    //               std::views::join_with(delim) | std::ranges::to<std::string>();
-    auto joined = join_with(names | std::views::transform(hdr_formatter), delim);
+    //               std::views::join_with(delim) |
+    //               std::ranges::to<std::string>();
+    auto joined =
+      join_with(names | std::views::transform(hdr_formatter), delim);
     if (write_n_cpgs)
       joined += std::format("{}{}", delim, "N_CPG");
     std::println(out, "{}", joined);

--- a/lib/counts_file_format.cpp
+++ b/lib/counts_file_format.cpp
@@ -26,6 +26,8 @@
 
 #include "zlib_adapter.hpp"
 
+#include "macos_helper.hpp"
+
 #include <algorithm>
 #include <cctype>  // for std::isdigit
 #include <cerrno>
@@ -70,7 +72,8 @@ parse_counts_line(const std::string &line, std::uint32_t &pos,
   // get level
   double meth{};
   field_s = field_e + 1;
-  res = std::from_chars(std::min(field_s, c_end), c_end, meth);
+  // res = std::from_chars(std::min(field_s, c_end), c_end, meth);
+  res = from_chars(std::min(field_s, c_end), c_end, meth);
   failed = failed || (res.ptr == c_end);
 
   // get n reads

--- a/lib/counts_file_format.hpp
+++ b/lib/counts_file_format.hpp
@@ -46,12 +46,12 @@ enum class counts_file_format : std::uint8_t {
   counts = 2,
 };
 
-using std::literals::string_view_literals::operator""sv;
+using std::literals::string_literals::operator""s;
 static constexpr auto counts_file_format_name = std::array{
   // clang-format off
-  "unknown"sv,
-  "xcounts"sv,
-  "counts"sv,
+  "unknown"s,
+  "xcounts"s,
+  "counts"s,
   // clang-format on
 };
 
@@ -69,11 +69,10 @@ template <>
 struct std::formatter<transferase::counts_file_format>
   : std::formatter<std::string> {
   auto
-  format(const transferase::counts_file_format &ff,
-         std::format_context &ctx) const {
-    const auto u = std::to_underlying(ff);
-    return std::format_to(ctx.out(), "{}",
-                          transferase::counts_file_format_name[u]);
+  format(const transferase::counts_file_format &x, auto &ctx) const {
+    const auto u = std::to_underlying(x);
+    const auto v = transferase::counts_file_format_name[u];
+    return std::formatter<std::string>::format(v, ctx);
   }
 };
 

--- a/lib/download_policy.cpp
+++ b/lib/download_policy.cpp
@@ -60,13 +60,3 @@ operator>>(std::istream &in, download_policy_t &dp) -> std::istream & {
 }
 
 }  // namespace transferase
-
-auto
-std::formatter<transferase::download_policy_t>::format(
-  const transferase::download_policy_t &dp,
-  std::format_context &ctx) const -> std::format_context::iterator {
-  return std::format_to(
-    ctx.out(), "{}",
-    // NOLINTNEXTLINE(*-array-index)
-    transferase::download_policy_t_name[std::to_underlying(dp)]);
-};

--- a/lib/download_policy.hpp
+++ b/lib/download_policy.hpp
@@ -113,8 +113,10 @@ template <>
 struct std::formatter<transferase::download_policy_t>
   : std::formatter<std::string> {
   auto
-  format(const transferase::download_policy_t &dp,
-         std::format_context &ctx) const -> std::format_context::iterator;
+  format(const transferase::download_policy_t &x, auto &ctx) const {
+    const auto v = get_download_policy_message(x);
+    return std::formatter<std::string>::format(v, ctx);
+  }
 };
 
 #endif  // LIB_DOWNLOAD_POLICY_HPP_

--- a/lib/format_error_code.hpp
+++ b/lib/format_error_code.hpp
@@ -34,8 +34,8 @@
 template <>
 struct std::formatter<std::error_code> : std::formatter<std::string> {
   auto
-  format(const std::error_code &e, std::format_context &ctx) const {
-    return std::format_to(ctx.out(), "{}", e.message());
+  format(const std::error_code &x, auto &ctx) const {
+    return std::formatter<std::string>::format(x.message(), ctx);
   }
 };
 

--- a/lib/genome_index_data.hpp
+++ b/lib/genome_index_data.hpp
@@ -136,9 +136,8 @@ template <>
 struct std::formatter<transferase::genome_index_data>
   : std::formatter<std::string> {
   auto
-  format(const transferase::genome_index_data &data,
-         std::format_context &ctx) const noexcept {
-    return std::format_to(ctx.out(), "{}", data.tostring());
+  format(const transferase::genome_index_data &x, auto &ctx) const {
+    return std::formatter<std::string>::format(x.tostring(), ctx);
   }
 };
 

--- a/lib/genome_index_metadata.hpp
+++ b/lib/genome_index_metadata.hpp
@@ -96,13 +96,13 @@ struct genome_index_metadata {
 
 }  // namespace transferase
 
+/// Specialization of std::format for genome_index_data
 template <>
 struct std::formatter<transferase::genome_index_metadata>
   : std::formatter<std::string> {
   auto
-  format(const transferase::genome_index_metadata &meta,
-         std::format_context &ctx) const {
-    return std::format_to(ctx.out(), "{}", meta.tostring());
+  format(const transferase::genome_index_metadata &x, auto &ctx) const {
+    return std::formatter<std::string>::format(x.tostring(), ctx);
   }
 };
 

--- a/lib/genomic_interval.hpp
+++ b/lib/genomic_interval.hpp
@@ -82,9 +82,9 @@ template <>
 struct std::formatter<transferase::genomic_interval>
   : std::formatter<std::string> {
   auto
-  format(const transferase::genomic_interval &gi,
-         std::format_context &ctx) const {
-    return std::format_to(ctx.out(), "{}\t{}\t{}", gi.ch_id, gi.start, gi.stop);
+  format(const transferase::genomic_interval &x, auto &ctx) const {
+    return std::formatter<std::string>::format(
+      std::format("{}\t{}\t{}", x.ch_id, x.start, x.stop), ctx);
   }
 };
 

--- a/lib/intervals_writer.cpp
+++ b/lib/intervals_writer.cpp
@@ -80,6 +80,7 @@ write_bedlike_intervals_impl(
       std::print(out, "\t{}", lvl_to_string(levels[j][i]));
     if (write_n_cpgs)
       std::print(out, "\t{}", n_cpgs[i]);
+    // std::println(out);
     std::print(out, "\n");
     ++i;
   }
@@ -133,6 +134,7 @@ write_intervals_dfscores_impl(const std::string &outfile,
         std::print(out, "\t{}", none_label);
     if (write_n_cpgs)
       std::print(out, "\t{}", n_cpgs[i]);
+    // std::println(out);
     std::print(out, "\n");
     ++i;
   }
@@ -198,6 +200,7 @@ write_intervals_dataframe_impl(
       std::print(out, "{}{}", delim, lvl_to_string(levels[j][i]));
     if (write_n_cpgs)
       std::print(out, "{}{}", delim, n_cpgs[i]);
+    // std::println(out);
     std::print(out, "\n");
     ++i;
   }

--- a/lib/intervals_writer.cpp
+++ b/lib/intervals_writer.cpp
@@ -31,6 +31,8 @@
 #include "level_element.hpp"
 #include "level_element_formatter.hpp"
 
+#include "macos_helper.hpp"
+
 #include <algorithm>  // IWYU pragma: keep (for transform)
 #include <cerrno>
 #include <format>
@@ -66,7 +68,9 @@ write_bedlike_intervals_impl(
   const auto n_levels = std::size(levels);
   auto prev_ch_id = genomic_interval::not_a_chrom;
   std::string chrom_name;
-  for (const auto [i, interval] : std::views::enumerate(intervals)) {
+  // for (const auto [i, interval] : std::views::enumerate(intervals)) {
+  std::uint32_t i = 0;
+  for (const auto &interval : intervals) {
     if (interval.ch_id != prev_ch_id) {
       chrom_name = meta.chrom_order[interval.ch_id];
       prev_ch_id = interval.ch_id;
@@ -76,7 +80,8 @@ write_bedlike_intervals_impl(
       std::print(out, "\t{}", lvl_to_string(levels[j][i]));
     if (write_n_cpgs)
       std::print(out, "\t{}", n_cpgs[i]);
-    std::println(out);
+    std::print(out, "\n");
+    ++i;
   }
   return {};
 }
@@ -92,7 +97,7 @@ write_intervals_dfscores_impl(const std::string &outfile,
                               const bool write_header) -> std::error_code {
   using std::literals::string_view_literals::operator""sv;
   static constexpr auto none_label = "NA"sv;
-  // static constexpr auto delim = '\t';
+  static constexpr auto delim = '\t';
 
   std::ofstream out(outfile);
   if (!out)
@@ -101,8 +106,9 @@ write_intervals_dfscores_impl(const std::string &outfile,
   const auto write_n_cpgs = !n_cpgs.empty();
 
   if (write_header) {
-    auto joined =
-      names | std::views::join_with('\t') | std::ranges::to<std::string>();
+    // auto joined =
+    //   names | std::views::join_with('\t') | std::ranges::to<std::string>();
+    auto joined = join_with(names, delim);
     if (write_n_cpgs)
       joined += "\tN_CPG";
     std::println(out, "{}", joined);
@@ -111,7 +117,9 @@ write_intervals_dfscores_impl(const std::string &outfile,
   const auto n_levels = std::size(levels);
   auto prev_ch_id = genomic_interval::not_a_chrom;
   std::string chrom_name;
-  for (const auto [i, interval] : std::views::enumerate(intervals)) {
+  // for (const auto [i, interval] : std::views::enumerate(intervals)) {
+  std::uint32_t i = 0;
+  for (const auto &interval : intervals) {
     if (interval.ch_id != prev_ch_id) {
       chrom_name = meta.chrom_order[interval.ch_id];
       prev_ch_id = interval.ch_id;
@@ -125,7 +133,8 @@ write_intervals_dfscores_impl(const std::string &outfile,
         std::print(out, "\t{}", none_label);
     if (write_n_cpgs)
       std::print(out, "\t{}", n_cpgs[i]);
-    std::println(out);
+    std::print(out, "\n");
+    ++i;
   }
   return {};
 }
@@ -152,7 +161,7 @@ write_intervals_dataframe_impl(
     return mode == level_element_mode::classic ? l.tostring_classic()
                                                : l.tostring_counts();
   };
-  const auto hdr_formatter = [mode](const auto &r) {
+  const auto hdr_formatter = [&](const auto &r) {
     return mode == level_element_mode::classic
              ? std::format(level_element::hdr_fmt_cls, r, delim, r, delim, r)
              : std::format(level_element::hdr_fmt, r, delim, r, delim, r);
@@ -165,8 +174,9 @@ write_intervals_dataframe_impl(
   const auto write_n_cpgs = !n_cpgs.empty();
 
   if (write_header) {
-    auto joined = names | std::views::transform(hdr_formatter) |
-                  std::views::join_with(delim) | std::ranges::to<std::string>();
+    // auto joined = names | std::views::transform(hdr_formatter) |
+    //               std::views::join_with(delim) | std::ranges::to<std::string>();
+    auto joined = join_with(names | std::views::transform(hdr_formatter), delim);
     if (write_n_cpgs)
       joined += std::format("{}{}", delim, "N_CPG");
     std::println(out, "{}", joined);
@@ -175,7 +185,9 @@ write_intervals_dataframe_impl(
   const auto n_levels = std::size(levels);
   auto prev_ch_id = genomic_interval::not_a_chrom;
   std::string chrom_name;
-  for (const auto [i, interval] : std::views::enumerate(intervals)) {
+  // for (const auto [i, interval] : std::views::enumerate(intervals)) {
+  std::uint32_t i = 0;
+  for (const auto &interval : intervals) {
     if (interval.ch_id != prev_ch_id) {
       chrom_name = meta.chrom_order[interval.ch_id];
       prev_ch_id = interval.ch_id;
@@ -186,7 +198,8 @@ write_intervals_dataframe_impl(
       std::print(out, "{}{}", delim, lvl_to_string(levels[j][i]));
     if (write_n_cpgs)
       std::print(out, "{}{}", delim, n_cpgs[i]);
-    std::println(out);
+    std::print(out, "\n");
+    ++i;
   }
   return {};
 }
@@ -226,7 +239,9 @@ write_bedlike_intervals_impl(
   auto prev_ch_id = genomic_interval::not_a_chrom;
   std::string chrom_name;
 
-  for (const auto [i, interval] : std::views::enumerate(intervals)) {
+  // for (const auto [i, interval] : std::views::enumerate(intervals)) {
+  std::uint32_t i = 0;
+  for (const auto &interval : intervals) {
     if (interval.ch_id != prev_ch_id) {
       chrom_name = meta.chrom_order[interval.ch_id];
       prev_ch_id = interval.ch_id;
@@ -244,6 +259,7 @@ write_bedlike_intervals_impl(
       push_buffer(cursor, line_end, error, delim, n_cpgs[i]);
     push_buffer(cursor, line_end, error, newline);
     out.write(line.data(), std::distance(line.data(), cursor));
+    ++i;
   }
   return {};
 }
@@ -275,8 +291,9 @@ write_intervals_dfscores_impl(
   const auto write_n_cpgs = !n_cpgs.empty();
 
   if (write_header) {
-    auto joined =
-      names | std::views::join_with(delim) | std::ranges::to<std::string>();
+    // auto joined =
+    //   names | std::views::join_with(delim) | std::ranges::to<std::string>();
+    auto joined = join_with(names, delim);
     if (write_n_cpgs)
       joined += std::format("{}{}", delim, "N_CPG"sv);
     std::println(out, "{}", joined);
@@ -291,7 +308,9 @@ write_intervals_dfscores_impl(
   const auto n_levels = levels.n_cols;
   auto prev_ch_id = genomic_interval::not_a_chrom;
   std::string chrom_name;
-  for (const auto [i, interval] : std::views::enumerate(intervals)) {
+  // for (const auto [i, interval] : std::views::enumerate(intervals)) {
+  std::uint32_t i = 0;
+  for (const auto &interval : intervals) {
     if (interval.ch_id != prev_ch_id) {
       chrom_name = meta.chrom_order[interval.ch_id];
       prev_ch_id = interval.ch_id;
@@ -308,6 +327,7 @@ write_intervals_dfscores_impl(
       push_buffer(cursor, line_end, error, delim, n_cpgs[i]);
     push_buffer(cursor, line_end, error, newline);
     out.write(line.data(), std::distance(line.data(), cursor));
+    ++i;
   }
   return {};
 }
@@ -330,7 +350,7 @@ write_intervals_dataframe_impl(
   static constexpr auto delim{'\t'};
   static constexpr auto newline{'\n'};
 
-  const auto hdr_formatter = [mode](const auto &r) {
+  const auto hdr_formatter = [&](const auto &r) {
     return mode == level_element_mode::classic
              ? std::format(level_element::hdr_fmt_cls, r, delim, r, delim, r)
              : std::format(level_element::hdr_fmt, r, delim, r, delim, r);
@@ -343,8 +363,9 @@ write_intervals_dataframe_impl(
   const auto write_n_cpgs = !n_cpgs.empty();
 
   if (write_header) {
-    auto joined = names | std::views::transform(hdr_formatter) |
-                  std::views::join_with(delim) | std::ranges::to<std::string>();
+    // auto joined = names | std::views::transform(hdr_formatter) |
+    //               std::views::join_with(delim) | std::ranges::to<std::string>();
+    auto joined = join_with(names | std::views::transform(hdr_formatter), delim);
     if (write_n_cpgs)
       joined += std::format("{}{}", delim, "N_CPG");
     std::println(out, "{}", joined);
@@ -360,7 +381,9 @@ write_intervals_dataframe_impl(
   auto prev_ch_id = genomic_interval::not_a_chrom;
   std::string chrom_name;
 
-  for (const auto [i, interval] : std::views::enumerate(intervals)) {
+  // for (const auto [i, interval] : std::views::enumerate(intervals)) {
+  std::uint32_t i = 0;
+  for (const auto &interval : intervals) {
     if (interval.ch_id != prev_ch_id) {
       chrom_name = meta.chrom_order[interval.ch_id];
       prev_ch_id = interval.ch_id;
@@ -377,6 +400,7 @@ write_intervals_dataframe_impl(
       push_buffer(cursor, line_end, error, delim, n_cpgs[i]);
     push_buffer(cursor, line_end, error, newline);
     out.write(line.data(), std::distance(line.data(), cursor));
+    ++i;
   }
   return {};
 }

--- a/lib/intervals_writer.cpp
+++ b/lib/intervals_writer.cpp
@@ -177,8 +177,10 @@ write_intervals_dataframe_impl(
 
   if (write_header) {
     // auto joined = names | std::views::transform(hdr_formatter) |
-    //               std::views::join_with(delim) | std::ranges::to<std::string>();
-    auto joined = join_with(names | std::views::transform(hdr_formatter), delim);
+    //               std::views::join_with(delim) |
+    //               std::ranges::to<std::string>();
+    auto joined =
+      join_with(names | std::views::transform(hdr_formatter), delim);
     if (write_n_cpgs)
       joined += std::format("{}{}", delim, "N_CPG");
     std::println(out, "{}", joined);
@@ -367,8 +369,10 @@ write_intervals_dataframe_impl(
 
   if (write_header) {
     // auto joined = names | std::views::transform(hdr_formatter) |
-    //               std::views::join_with(delim) | std::ranges::to<std::string>();
-    auto joined = join_with(names | std::views::transform(hdr_formatter), delim);
+    //               std::views::join_with(delim) |
+    //               std::ranges::to<std::string>();
+    auto joined =
+      join_with(names | std::views::transform(hdr_formatter), delim);
     if (write_n_cpgs)
       joined += std::format("{}{}", delim, "N_CPG");
     std::println(out, "{}", joined);

--- a/lib/level_element.hpp
+++ b/lib/level_element.hpp
@@ -136,10 +136,10 @@ template <>
 struct std::formatter<transferase::level_element_t>
   : std::formatter<std::string> {
   auto
-  format(const transferase::level_element_t &l,
-         std::format_context &ctx) const {
-    return std::format_to(ctx.out(), R"({{"n_meth": {}, "n_unmeth": {}}})",
-                          l.n_meth, l.n_unmeth);
+  format(const transferase::level_element_t &x, auto &ctx) const {
+    return std::formatter<std::string>::format(
+      std::format(R"({{"n_meth": {}, "n_unmeth": {}}})", x.n_meth, x.n_unmeth),
+      ctx);
   }
 };
 
@@ -147,11 +147,11 @@ template <>
 struct std::formatter<transferase::level_element_covered_t>
   : std::formatter<std::string> {
   auto
-  format(const transferase::level_element_covered_t &l,
-         std::format_context &ctx) const {
-    return std::format_to(
-      ctx.out(), R"({{"n_meth": {}, "n_unmeth": {}, "n_covered": {}}})",
-      l.n_meth, l.n_unmeth, l.n_covered);
+  format(const transferase::level_element_covered_t &x, auto &ctx) const {
+    return std::formatter<std::string>::format(
+      std::format(R"({{"n_meth": {}, "n_unmeth": {}, "n_covered": {}}})",
+                  x.n_meth, x.n_unmeth, x.n_covered),
+      ctx);
   }
 };
 

--- a/lib/logger.hpp
+++ b/lib/logger.hpp
@@ -327,9 +327,10 @@ to_string(const transferase::log_level_t l) -> std::string {
 template <>
 struct std::formatter<transferase::log_level_t> : std::formatter<std::string> {
   auto
-  format(const transferase::log_level_t lvl, std::format_context &ctx) const {
-    const auto l = std::to_underlying(lvl);
-    return std::format_to(ctx.out(), "{}", transferase::level_name[l]);
+  format(const transferase::log_level_t &x, auto &ctx) const {
+    const auto u = std::to_underlying(x);
+    return std::formatter<std::string>::format(transferase::level_name_str[u],
+                                               ctx);
   }
 };
 

--- a/lib/macos_helper.hpp
+++ b/lib/macos_helper.hpp
@@ -27,9 +27,9 @@
 // ADS: this file exists because in 2025, Apple Clang doesn't yet fully
 // support even C++17
 
+#include <charconv>
 #include <format>
 #include <string>
-#include <charconv>
 
 namespace transferase {
 
@@ -62,6 +62,5 @@ join_with(const auto &tokens, const char delim) -> std::string {
   }
   return joined;
 }
-
 
 #endif  // LIB_MACOS_HELPER_HPP_

--- a/lib/macos_helper.hpp
+++ b/lib/macos_helper.hpp
@@ -1,0 +1,67 @@
+/* MIT License
+ *
+ * Copyright (c) 2025 Andrew D Smith
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef LIB_MACOS_HELPER_HPP_
+#define LIB_MACOS_HELPER_HPP_
+
+// ADS: this file exists because in 2025, Apple Clang doesn't yet fully
+// support even C++17
+
+#include <format>
+#include <string>
+#include <charconv>
+
+namespace transferase {
+
+[[nodiscard]] static inline auto
+from_chars(const char *first, const char *last,
+           double &value) -> std::from_chars_result {
+  // ADS: should be same as return std::from_chars(first, last, value);
+  char *last_ptr{};
+  value = strtod(first, &last_ptr);
+  std::from_chars_result res;
+  res.ptr = last_ptr;
+  res.ec = (last_ptr == first || (last_ptr != last && std::isgraph(*last_ptr)))
+             ? std::errc::invalid_argument
+           : errno ? std::errc(errno)
+                   : std::errc{};
+  return res;
+}
+
+}  // namespace transferase
+
+[[nodiscard]] inline auto
+join_with(const auto &tokens, const char delim) -> std::string {
+  std::string joined;
+  bool first = true;
+  for (const auto &token : tokens) {
+    if (!first)
+      joined += delim;
+    joined += token;
+    first = false;
+  }
+  return joined;
+}
+
+
+#endif  // LIB_MACOS_HELPER_HPP_

--- a/lib/methylome_metadata.hpp
+++ b/lib/methylome_metadata.hpp
@@ -107,9 +107,8 @@ template <>
 struct std::formatter<transferase::methylome_metadata>
   : std::formatter<std::string> {
   auto
-  format(const transferase::methylome_metadata &mm,
-         std::format_context &ctx) const {
-    return std::format_to(ctx.out(), "{}", mm.tostring());
+  format(const transferase::methylome_metadata &x, auto &ctx) const {
+    return std::formatter<std::string>::format(x.tostring(), ctx);
   }
 };
 

--- a/lib/output_format_type.cpp
+++ b/lib/output_format_type.cpp
@@ -67,12 +67,16 @@ operator>>(std::istream &in,
     return in;
   }
 
-  for (const auto [i, name] :
-       std::views::enumerate(transferase::output_format_t_name))
+  // for (const auto [i, name] :
+  //        std::views::enumerate(transferase::output_format_t_name))
+  std::uint32_t i = 0;
+  for (const auto &name : transferase::output_format_t_name) {
     if (tmp == name) {
       of = static_cast<transferase::output_format_t>(i);
       return in;
     }
+    ++i;
+  }
   in.setstate(std::ios::failbit);
   return in;
 }

--- a/lib/output_format_type.hpp
+++ b/lib/output_format_type.hpp
@@ -81,11 +81,11 @@ template <>
 struct std::formatter<transferase::output_format_t>
   : std::formatter<std::string> {
   auto
-  format(const transferase::output_format_t &of,
-         std::format_context &ctx) const {
-    return std::format_to(
-      ctx.out(), "{}",
-      transferase::output_format_t_name[std::to_underlying(of)]);
+  format(const transferase::output_format_t &x, auto &ctx) const {
+    const auto u = std::to_underlying(x);
+    const auto v = transferase::output_format_t_name[u];
+    return std::formatter<std::string>::format(
+      std::string(std::cbegin(v), std::cend(v)), ctx);
   }
 };
 

--- a/lib/remote_data_resource.hpp
+++ b/lib/remote_data_resource.hpp
@@ -85,9 +85,9 @@ template <>
 struct std::formatter<transferase::remote_data_resource>
   : std::formatter<std::string> {
   auto
-  format(const transferase::remote_data_resource &r,
-         std::format_context &ctx) const {
-    return std::format_to(ctx.out(), "{}:{}{}", r.hostname, r.port, r.path);
+  format(const transferase::remote_data_resource &r, auto &ctx) const {
+    return std::formatter<std::string>::format(
+      std::format("{}:{}{}", r.hostname, r.port, r.path), ctx);
   }
 };
 

--- a/lib/request.hpp
+++ b/lib/request.hpp
@@ -124,13 +124,13 @@ parse(const request_buffer &buf, request &req) -> std::error_code;
 template <>
 struct std::formatter<transferase::request> : std::formatter<std::string> {
   auto
-  format(const transferase::request &r, std::format_context &ctx) const {
+  format(const transferase::request &r, auto &ctx) const {
     std::string s;
     s += std::format("{}\t{}\t{}", to_string(r.request_type), r.index_hash,
                      r.aux_value);
     for (const auto &methylome_name : r.methylome_names)
       s += std::format("\t{}", methylome_name);
-    return std::format_to(ctx.out(), "{}\n", s);
+    return std::formatter<std::string>::format(s, ctx);
   }
 };
 

--- a/lib/request_type_code.hpp
+++ b/lib/request_type_code.hpp
@@ -65,9 +65,9 @@ struct std::formatter<transferase::request_type_code>
   : std::formatter<std::string> {
   /// Specialization of std::format for request_type_code
   auto
-  format(const transferase::request_type_code &rtc,
-         std::format_context &ctx) const {
-    return std::format_to(ctx.out(), "{}", std::to_underlying(rtc));
+  format(const transferase::request_type_code &rtc, auto &ctx) const {
+    return std::formatter<std::string>::format(
+      std::format("{}", std::to_underlying(rtc)), ctx);
   }
 };
 

--- a/lib/server.cpp
+++ b/lib/server.cpp
@@ -368,7 +368,6 @@ server::run() -> void {
   // If not using std::jthread, then join the std::thread
   for (std::uint32_t i = 0; i < n_threads; ++i)
     threads[i].join();
-
 }
 
 auto

--- a/lib/server.cpp
+++ b/lib/server.cpp
@@ -357,9 +357,18 @@ server::run() -> void {
      are equivalent and the io_context may choose any one of them to
      invoke a handler."
   */
-  std::vector<std::jthread> threads;
+  // std::vector<std::jthread> threads;
+  // for (std::uint32_t i = 0; i < n_threads; ++i)
+  //   threads.emplace_back([this] { ioc.run(); });  // NOLINT
+
+  std::vector<std::thread> threads;
   for (std::uint32_t i = 0; i < n_threads; ++i)
     threads.emplace_back([this] { ioc.run(); });  // NOLINT
+
+  // If not using std::jthread, then join the std::thread
+  for (std::uint32_t i = 0; i < n_threads; ++i)
+    threads[i].join();
+
 }
 
 auto

--- a/lib/system_config.hpp
+++ b/lib/system_config.hpp
@@ -64,23 +64,6 @@ get_transferase_server_info() -> std::tuple<std::string, std::string>;
 get_transferase_server_info(const std::string &data_dir)
   -> std::tuple<std::string, std::string>;
 
-// [[nodiscard]] auto
-// get_remote_data_resource() -> std::vector<remote_data_resource>;
-
-// [[nodiscard]] auto
-// get_remote_data_resource(const std::string &data_dir)
-//   -> std::vector<remote_data_resource>;
-
 }  // namespace transferase
-
-// template <>
-// struct std::formatter<transferase::remote_data_resource>
-//   : std::formatter<std::string> {
-//   auto
-//   format(const transferase::remote_data_resource &r,
-//          std::format_context &ctx) const {
-//     return std::format_to(ctx.out(), "{}:{}{}", r.tostring());
-//   }
-// };
 
 #endif  // LIB_SYSTEM_CONFIG_HPP_

--- a/lib/tests/download_test.cpp
+++ b/lib/tests/download_test.cpp
@@ -24,6 +24,7 @@
 #include <download.hpp>
 
 #include <http_error_code.hpp>
+#include <macos_helper.hpp>
 
 #include "unit_test_utils.hpp"
 
@@ -44,8 +45,9 @@ to_string(const auto &maplike) -> std::string {
   const auto fmt_pair = [](const auto &pairlike) -> std::string {
     return std::format("\"{}\":\"{}\"", pairlike.first, pairlike.second);
   };
-  return maplike | std::views::transform(fmt_pair) |
-         std::views::join_with('\n') | std::ranges::to<std::string>();
+  // return maplike | std::views::transform(fmt_pair) |
+  //        std::views::join_with('\n') | std::ranges::to<std::string>();
+  return join_with(maplike | std::views::transform(fmt_pair), '\n');
 }
 
 TEST(download_test, send_request_timeout) {

--- a/lib/tests/methylome_set_test.cpp
+++ b/lib/tests/methylome_set_test.cpp
@@ -93,12 +93,16 @@ protected:
       "tail",
       "ear",
     };
-    accessions =
-      std::views::cartesian_product(species, tissues) |
-      std::views::transform([](const auto &both) {
-        return std::format("{}_{}", std::get<0>(both), std::get<1>(both));
-      }) |
-      std::ranges::to<std::vector>();
+    for (const auto &s : species)
+      for (const auto &t : tissues)
+        accessions.push_back(std::format("{}_{}", s, t));
+
+    // accessions =
+    //   std::views::cartesian_product(species, tissues) |
+    //   std::views::transform([](const auto &both) {
+    //     return std::format("{}_{}", std::get<0>(both), std::get<1>(both));
+    //   }) |
+    //   std::ranges::to<std::vector>();
 
     max_live_methylomes = 3;
     methylome_directory = "data/lutions/methylomes";


### PR DESCRIPTION
Apple support for C++ standards is terrible. This PR involves many re-writes and workarounds to allow all the code for the lib and cli and their tests to build with Apple Clang 16