### PR TITLE
Updating the name of the methbase metadata file

### DIFF
--- a/R/R/exports.R
+++ b/R/R/exports.R
@@ -100,16 +100,16 @@ get_wmeans <- function(levels_matrix, has_n_covered, min_count = 1) {
   .Call(`_Rxfr_get_wmeans`, levels_matrix, has_n_covered, min_count)
 }
 
-#' Load transferase metadata
+#' Load methbase metadata
 #'
-#' Load a data frame with the current transferase metadata.
+#' Load a data frame with the current metadata from MethBase2.
 #'
 #' @param genome The reference genome for which you want metadata.
 #'
 #' @param config_dir The configuration directory. Unless set specifically with
 #'   the config_xfr() function, this should be left empty.
 #'
-#' @return A data frame with the current transferase metadata.
+#' @return A data frame with the current MethBase2 metadata.
 #'
 #' @details
 #'
@@ -162,8 +162,8 @@ get_wmeans <- function(levels_matrix, has_n_covered, min_count = 1) {
 #' @examples
 #' # Mostly leave the config_dir empty
 #' config_xfr(c("hg38"), "usually_left_empty")
-#' meta <- load_xfr_metadata("hg38", "usually_left_empty")
-load_xfr_metadata <- function(genome, config_dir = "") {
+#' meta <- load_methbase_metadata("hg38", "usually_left_empty")
+load_methbase_metadata <- function(genome, config_dir = "") {
   if (config_dir == "") {
     home_dir <- Sys.getenv("HOME")
     config_dir <- file.path(home_dir, ".config", "transferase")
@@ -175,7 +175,7 @@ load_xfr_metadata <- function(genome, config_dir = "") {
                                packageVersion("Rxfr"))
   metadata_path <- file.path(config_dir, metadata_filename)
   if (!file.exists(metadata_path)) {
-    fmt <- "config file does not exist: %s. See the config_xfr function"
+    fmt <- "metadata file does not exist: %s. See the config_xfr function"
     stop(sprintf(fmt, metadata_path), call. = FALSE)
   }
   full_table <- read.table(metadata_path, header=TRUE)

--- a/R/R/exports.R
+++ b/R/R/exports.R
@@ -171,7 +171,7 @@ load_methbase_metadata <- function(genome, config_dir = "") {
     fmt <- "directory does not exist: %s. See the config_xfr function"
     stop(sprintf(fmt, config_dir), call. = FALSE)
   }
-  metadata_filename <- sprintf("metadata_dataframe_%s.tsv",
+  metadata_filename <- sprintf("methbase_metadata_dataframe_%s.tsv",
                                packageVersion("Rxfr"))
   metadata_path <- file.path(config_dir, metadata_filename)
   if (!file.exists(metadata_path)) {

--- a/cli/command_config.cpp
+++ b/cli/command_config.cpp
@@ -120,7 +120,7 @@ command_config_main(int argc, char *argv[]) -> int {  // NOLINT(*-c-arrays)
   app.add_option("-p,--port", cfg.port, "transferase server port");
   app.add_option("-x,--index-dir", cfg.index_dir,
                  "name of a directory to store genome index files");
-  app.add_option("--metadata-dataframe", cfg.metadata_dataframe,
+  app.add_option("--methbase-metadata", cfg.methbase_metadata_dataframe,
                  "name of the MethBase2 metadata dataframe");
   app.add_option("--methylome-list", cfg.methylome_list,
                  "name of the methylome list (for a remote or local server)");
@@ -230,7 +230,7 @@ command_config_main(int argc, char *argv[]) -> int {  // NOLINT(*-c-arrays)
     {"Port", or_none(cfg.port)},
     {"Index dir", or_none(cfg.index_dir)},
     {"Methylome dir", or_none(cfg.methylome_dir)},
-    {"Metadata dataframe", or_none(cfg.metadata_dataframe)},
+    {"Metadata dataframe", or_none(cfg.methbase_metadata_dataframe)},
     {"Select metadata", or_none(cfg.select_metadata)},
     {"Methylome list", or_none(cfg.methylome_list)},
     {"Log level", to_string(cfg.log_level)},

--- a/docs/r.md
+++ b/docs/r.md
@@ -30,10 +30,11 @@ Likely that won't work, so see
 
 ### Load transferase metadata
 
-The `load_xfr_metadata` function will return a data frame with metadata about
-the methylomes you can query using transferase. These are the high-quality
-methylomes in MethBase2. The `load_xfr_metadata` function needs the name of a
-reference genome (the assembly, using UCSC Genome Browser names, like hg38).
+The `load_methbase_metadata` function will return a data frame with metadata
+about the methylomes you can query using transferase. These are the
+high-quality methylomes in MethBase2. The `load_methbase_metadata` function
+needs the name of a reference genome (the assembly, using UCSC Genome Browser
+names, like hg38).
 
 Usage:
 ```R

--- a/lib/client_config.hpp
+++ b/lib/client_config.hpp
@@ -46,15 +46,15 @@ struct client_config {
   static constexpr auto client_log_filename_default = "transferase.log";
   static constexpr auto client_config_filename_default =
     "transferase_client_{}.json";
-  static constexpr auto metadata_dataframe_default =
-    "metadata_dataframe_{}.tsv";
+  static constexpr auto methbase_metadata_dataframe_default =
+    "methbase_metadata_dataframe_{}.tsv";
   static constexpr auto select_metadata_default = "select_metadata_{}.json";
 
   std::string config_dir;
   std::string hostname;
   std::string port{};
   std::string index_dir;
-  std::string metadata_dataframe;
+  std::string methbase_metadata_dataframe;
   std::string select_metadata;
   std::string methylome_list;
   std::string methylome_dir;
@@ -88,7 +88,7 @@ struct client_config {
 
   /// Get the path to the metadata dataframe file
   [[nodiscard]] auto
-  get_metadata_dataframe_file() const noexcept -> std::string;
+  get_methbase_metadata_dataframe_file() const noexcept -> std::string;
 
   /// Get the path to the labels file
   [[nodiscard]] auto
@@ -190,9 +190,9 @@ struct client_config {
   client_config() = default;
 
   NLOHMANN_DEFINE_TYPE_INTRUSIVE(client_config, config_dir, hostname, port,
-                                 index_dir, methylome_dir, metadata_dataframe,
-                                 select_metadata, methylome_list, log_file,
-                                 log_level)
+                                 index_dir, methylome_dir,
+                                 methbase_metadata_dataframe, select_metadata,
+                                 methylome_list, log_file, log_level)
 };
 
 }  // namespace transferase

--- a/lib/remote_data_resource.hpp
+++ b/lib/remote_data_resource.hpp
@@ -57,9 +57,10 @@ struct remote_data_resource {
   /// Used to identify both the remote url and local relative path for
   /// metadata table.
   [[nodiscard]] auto
-  form_metadata_dataframe_target() const {
+  form_methbase_metadata_dataframe_target() const {
     return (std::filesystem::path{path} / "metadata" / "latest" /
-            std::format(client_config::metadata_dataframe_default, VERSION))
+            std::format(client_config::methbase_metadata_dataframe_default,
+                        VERSION))
       .string();
   }
 

--- a/lib/tests/client_config_test.cpp
+++ b/lib/tests/client_config_test.cpp
@@ -53,7 +53,7 @@ protected:
     "index_dir": "",
     "log_file": "",
     "log_level": "debug",
-    "metadata_dataframe": "",
+    "methbase_metadata_dataframe": "",
     "methylome_list": "",
     "select_metadata": "",
     "labels_file": "",
@@ -159,7 +159,7 @@ TEST_F(client_config_mock, get_defaults_success) {
   EXPECT_FALSE(error);
 
   EXPECT_NE(cfg.index_dir, std::string{});
-  EXPECT_NE(cfg.metadata_dataframe, std::string{});
+  EXPECT_NE(cfg.methbase_metadata_dataframe, std::string{});
 
   EXPECT_FALSE(cfg.hostname.empty());
   EXPECT_FALSE(cfg.port.empty());
@@ -210,7 +210,7 @@ TEST_F(client_config_mock, re_read_config_file_success) {
   EXPECT_EQ(cfg.methylome_dir, mock_methylome_dir);
   EXPECT_EQ(cfg.port, "");
   EXPECT_EQ(cfg.index_dir, "");
-  EXPECT_EQ(cfg.metadata_dataframe, "");
+  EXPECT_EQ(cfg.methbase_metadata_dataframe, "");
 
   std::error_code error;
   cfg.read_config_file_no_overwrite(error);
@@ -220,7 +220,8 @@ TEST_F(client_config_mock, re_read_config_file_success) {
   EXPECT_EQ(cfg.methylome_dir, mock_methylome_dir) << cfg.tostring() << "\n";
   EXPECT_EQ(cfg.port, "9000") << cfg.tostring() << "\n";
   EXPECT_EQ(cfg.index_dir, "indexes") << cfg.tostring() << "\n";
-  EXPECT_EQ(cfg.metadata_dataframe, std::string{}) << cfg.tostring() << "\n";
+  EXPECT_EQ(cfg.methbase_metadata_dataframe, std::string{})
+    << cfg.tostring() << "\n";
   EXPECT_EQ(cfg.methylome_list, std::format("methylome_list_{}.json", VERSION))
     << cfg.tostring() << "\n";
 }

--- a/lib/tests/remote_data_resource_test.cpp
+++ b/lib/tests/remote_data_resource_test.cpp
@@ -48,7 +48,8 @@ TEST(remote_data_resource_test, form_index_target_stem_success) {
     << index_target_stem << "\t" << expected;
 }
 
-TEST(remote_data_resource_test, form_metadata_dataframe_target_stem_success) {
+TEST(remote_data_resource_test,
+     form_methbase_metadata_dataframe_target_stem_success) {
   static const auto expected =
     std::format("metadata/latest/select_metadata_{}.json", VERSION);
   remote_data_resource rdr;

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,17 +1,12 @@
-"""pyxfr: the transferase Python API. See help for individual classes.
+"""
+pyxfr: the transferase Python API. For detailed help, see individual modules
+within this package:
 
-Transeferase is a system for downloading DNA methylation data from the
-MethBase2 database. You can also use it with your own data. If you
-want to list the classes available in this Python API, you can do the
-following:
-
-  import pyxfr, inspect
-  classes = [
-      cls for cls, obj in inspect.getmembers(transferase, inspect.isclass)
-  ]
-  print(classes)
+  >>> from pyxfr import pyxfr, pyxfr_utils
+  >>> help(pyxfr)
+  >>> help(pyxfr_utils)
 """
 
 from .pyxfr import *
 
-from .pyxfr_utils import *
+from .pyxfr_utils import generate_bins, load_methbase_metadata

--- a/python/pyxfr/client_config_bindings.cpp
+++ b/python/pyxfr/client_config_bindings.cpp
@@ -146,7 +146,8 @@ client_config_bindings(nanobind::class_<transferase::client_config> &cls)
     'index_dir' there is no reason to change this unless you are working with
     your own data.
     )doc");
-  cls.def_rw("metadata_dataframe", &xfr::client_config::metadata_dataframe,
+  cls.def_rw("methbase_metadata_dataframe",
+             &xfr::client_config::methbase_metadata_dataframe,
              R"doc(
     If this value is non-empty, it is the name of a file with rows
     corresponding to methylomes. This file is fetched when configuring

--- a/python/pyxfr_utils.py
+++ b/python/pyxfr_utils.py
@@ -100,7 +100,7 @@ def load_methbase_metadata(genome, config_dir=None):
         )
     from .pyxfr import __version__ as pyxfr_version
 
-    metadata_filename = f"metadata_dataframe_{pyxfr_version}.tsv"
+    metadata_filename = f"methbase_metadata_dataframe_{pyxfr_version}.tsv"
     metadata_path = os.path.join(config_dir, metadata_filename)
     if not os.path.exists(metadata_path):
         raise OSError(

--- a/test_data/lutions/transferase_client_0.6.0.json
+++ b/test_data/lutions/transferase_client_0.6.0.json
@@ -4,7 +4,7 @@
     "port": "9000",
     "index_dir": "indexes",
     "methylome_list": "methylome_list_0.6.0.json",
-    "metadata_dataframe": "",
+    "methbase_metadata_dataframe": "",
     "select_metadata": "",
     "methylome_dir": "methylomes",
     "log_file": "",


### PR DESCRIPTION
By naming this with methbase, nobody will be confused about what this is or where it comes from, and they won't confuse it with their own metadata