### PR TITLE
Adding group names in the select command

### DIFF
--- a/cli/cli_common.hpp
+++ b/cli/cli_common.hpp
@@ -26,6 +26,9 @@
 
 #include "CLI11/CLI11.hpp"
 
+#include <string>
+#include <vector>
+
 static const int column_width_default = 30;
 
 class transferase_formatter : public CLI::Formatter {

--- a/cli/command_query.cpp
+++ b/cli/command_query.cpp
@@ -63,6 +63,7 @@ xfr query --local -d methylome_dir -x index_dir -g hg38 \
 #include "intervals_writer.hpp"
 #include "level_element.hpp"
 #include "logger.hpp"
+#include "macos_helper.hpp"
 #include "methylome.hpp"
 #include "methylome_interface.hpp"
 #include "output_format_type.hpp"
@@ -71,9 +72,8 @@ xfr query --local -d methylome_dir -x index_dir -g hg38 \
 #include "request_type_code.hpp"
 #include "utilities.hpp"
 
-#include "macos_helper.hpp"
-
 #include "CLI11/CLI11.hpp"
+#include "nlohmann/json.hpp"
 
 #include <asio.hpp>
 
@@ -280,7 +280,7 @@ do_bins_query(const std::uint32_t bin_size,
 
 [[nodiscard]] static inline auto
 read_methylomes_json(const std::string &json_filename, std::error_code &ec)
-  -> std::pair<std::vector<std::string>, std::vector<std::string>> {
+  -> std::tuple<std::vector<std::string>, std::vector<std::string>> {
   std::ifstream in(json_filename);
   if (!in) {
     ec = std::make_error_code(std::errc(errno));
@@ -295,7 +295,7 @@ read_methylomes_json(const std::string &json_filename, std::error_code &ec)
   try {
     should_be_pairs = data;
   }
-  catch (const std::exception &_) {
+  catch (const json::exception &_) {
     ec = std::make_error_code(std::errc::invalid_argument);
     return {{}, {}};
   }
@@ -311,7 +311,7 @@ read_methylomes_json(const std::string &json_filename, std::error_code &ec)
 [[nodiscard]] static inline auto
 get_methylome_names(const std::vector<std::string> &possibly_methylome_names,
                     std::error_code &error)
-  -> std::pair<std::vector<std::string>, std::vector<std::string>> {
+  -> std::tuple<std::vector<std::string>, std::vector<std::string>> {
   if (possibly_methylome_names.size() > 1)
     return {possibly_methylome_names, possibly_methylome_names};
   const bool is_file =

--- a/cli/command_query.cpp
+++ b/cli/command_query.cpp
@@ -295,7 +295,7 @@ read_methylomes_json(const std::string &json_filename, std::error_code &ec)
   try {
     should_be_pairs = data;
   }
-  catch (const json::exception &_) {
+  catch (const nlohmann::json::exception &_) {
     ec = std::make_error_code(std::errc::invalid_argument);
     return {{}, {}};
   }

--- a/cli/command_select.cpp
+++ b/cli/command_select.cpp
@@ -58,13 +58,10 @@ command_select_main([[maybe_unused]] int argc,
 
 #include "cli_common.hpp"
 #include "client_config.hpp"
-#include "nlohmann/json.hpp"
+#include "macos_helper.hpp"
 #include "utilities.hpp"
 
-#include "macos_helper.hpp"
-
 #include "CLI11/CLI11.hpp"
-
 #include "nlohmann/json.hpp"
 
 #include <ncurses.h>

--- a/cli/command_select.cpp
+++ b/cli/command_select.cpp
@@ -131,6 +131,7 @@ load_data(const std::string &json_filename, std::error_code &error)
 
 static auto
 mvprintw_wrap(const int x, const int y, const std::string &s) {
+  // NLINTNEXTLINE (*-vararg)
   const auto ret = mvprintw(x, y, "%s", s.substr(0, COLS - 1).data());
   if (ret != OK)
     throw std::runtime_error(
@@ -147,7 +148,7 @@ get_to_show(const auto &filtered, const auto disp_start, const auto disp_end) {
 format_current_entry(const auto &entry, const auto horiz_pos,
                      const bool show_details) {
   // Form the label by appending the colon
-  const auto label = std::format("{}: ", std::get<0>(entry));
+  auto label = std::format("{}: ", std::get<0>(entry));
 
   auto sample_name = std::get<1>(entry);
   if (show_details)

--- a/cli/command_select.cpp
+++ b/cli/command_select.cpp
@@ -131,7 +131,7 @@ load_data(const std::string &json_filename, std::error_code &error)
 
 static auto
 mvprintw_wrap(const int x, const int y, const std::string &s) {
-  // NLINTNEXTLINE (*-vararg)
+  // NOLINTNEXTLINE (*-vararg)
   const auto ret = mvprintw(x, y, "%s", s.substr(0, COLS - 1).data());
   if (ret != OK)
     throw std::runtime_error(

--- a/lib/client_config.cpp
+++ b/lib/client_config.cpp
@@ -36,11 +36,11 @@
 #include <cassert>
 #include <chrono>  // for std::chrono::operator-
 #include <cstdlib>
-#include <exception>  // for std::exception
 #include <filesystem>
 #include <format>
 #include <fstream>
 #include <iterator>  // for std::size
+#include <stdexcept>
 #include <string>
 #include <system_error>
 #include <unordered_map>
@@ -342,7 +342,7 @@ client_config::read_config_file(const std::string &config_file,
   try {
     config = data;
   }
-  catch (const std::exception &e) {
+  catch (const nlohmann::json::exception &_) {
     error = client_config_error_code::invalid_client_config_file;
     return {};
   }

--- a/lib/output_format_type.cpp
+++ b/lib/output_format_type.cpp
@@ -56,7 +56,7 @@ operator>>(std::istream &in,
   if (std::ranges::all_of(tmp, is_digit)) {
     std::underlying_type_t<transferase::output_format_t> num{};
     const auto last = tmp.data() + std::size(tmp);  // NOLINT
-    const auto res  = std::from_chars(tmp.data(), last, num);
+    const auto res = std::from_chars(tmp.data(), last, num);
     if (res.ptr != last) {
       in.setstate(std::ios::failbit);
       return in;

--- a/lib/output_format_type.hpp
+++ b/lib/output_format_type.hpp
@@ -34,7 +34,8 @@
 #include <string_view>
 #include <utility>  // for std::to_underlying
 
-static const std::string output_format_details = R"(
+// NOLINTNEXTLINE
+static const auto output_format_details = R"(
 The output formats for the 'query' command are the following:
 
 * classic


### PR DESCRIPTION
This will allow for users to form groups of methylomes, name methylomes based on those groups, and have the output of queries on the command line use those as column headings