### PR TITLE
Fixing default server max resident logic

### DIFF
--- a/R/integration_tests.R
+++ b/R/integration_tests.R
@@ -67,7 +67,7 @@ levels <- client$do_query(methylomes, intervals, genome,
                           add_n_cpgs = TRUE, add_header = TRUE)
 print(head(levels))
 
-levels <- client$do_query(methylomes, bin_size)
+levels <- client$do_query(methylomes, bin_size, genome)
 print(head(levels))
 
 levels <- client$do_query(methylomes, query)
@@ -79,7 +79,7 @@ levels <- client$do_query(methylomes, intervals, genome,
                           add_rownames = TRUE)
 print(head(levels))
 
-levels <- client$do_query(methylomes, bin_size, genome = genome,
+levels <- client$do_query(methylomes, bin_size, genome,
                           covered = TRUE, add_rownames = TRUE)
 print(head(levels))
 

--- a/lib/server_config.cpp
+++ b/lib/server_config.cpp
@@ -146,7 +146,11 @@ server_config::read_config_file_no_overwrite(
 
   if (n_threads == 1)
     n_threads = tmp.n_threads;
-  if (max_resident == 0)
+
+  // replace the max_resident if it seems as though max_resident was set to 0
+  // (invalid) or set to 1, in which case the read value would be at least as
+  // large.
+  if (max_resident <= 1 && tmp.max_resident > 1)
     max_resident = tmp.max_resident;
   if (min_bin_size == 0)
     min_bin_size = tmp.min_bin_size;

--- a/lib/server_config.hpp
+++ b/lib/server_config.hpp
@@ -40,7 +40,7 @@ struct server_config {
   static constexpr auto max_n_threads = 1024;
   static constexpr auto max_max_resident = 8192;
   static constexpr auto default_n_threads = 1;
-  static constexpr auto default_max_resident = 128;
+  static constexpr auto default_max_resident = 1;
   static constexpr auto server_config_filename_default =
     "transferase_server.json";
 


### PR DESCRIPTION
Previously the value in the config file was being ignored due to a bug