### PR TITLE
Query json input format change

### DIFF
--- a/cli/command_query.cpp
+++ b/cli/command_query.cpp
@@ -313,9 +313,9 @@ read_methylomes_json(const std::string &json_filename, std::error_code &ec)
     ec = std::make_error_code(std::errc::invalid_argument);
     return {{}, {}};
   }
-  std::map<std::string, std::string> name_alt;
+  std::map<std::string, std::string> altname_name;
   try {
-    name_alt = data;
+    altname_name = data;
   }
   catch (const nlohmann::json::exception &_) {
     ec = std::make_error_code(std::errc::invalid_argument);
@@ -323,15 +323,13 @@ read_methylomes_json(const std::string &json_filename, std::error_code &ec)
   }
 
   std::vector<std::pair<std::string, std::string>> sorted_by_alt;
-  std::ranges::copy(name_alt, std::back_inserter(sorted_by_alt));
+  std::ranges::copy(altname_name, std::back_inserter(sorted_by_alt));
 
-  std::ranges::sort(sorted_by_alt, [](const auto &a, const auto &b) {
-    return a.second < b.second;
-  });
+  std::ranges::sort(sorted_by_alt);
 
   std::vector<std::string> names;
   std::vector<std::string> alt_names;
-  for (const auto &[name, alt_name] : sorted_by_alt) {
+  for (const auto &[alt_name, name] : sorted_by_alt) {
     names.push_back(name);
     alt_names.push_back(alt_name);
   }

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -508,23 +508,21 @@ specify methylomes. All of them use the `-m` or `--methylomes` argument.
 
    ```json
    {
-       "SRX10768294": "b_cell_00004",
-       "SRX10768295": "b_cell_00003",
-       "SRX10768296": "b_cell_00002",
-       "SRX10768297": "b_cell_00001",
-       "SRX12292982": "t_cell_00004",
-       "SRX12292983": "t_cell_00002",
-       "SRX12292984": "t_cell_00003",
-       "SRX12292985": "t_cell_00001"
+       "b_cell_00001": "SRX10768297",
+       "b_cell_00002": "SRX10768296",
+       "b_cell_00003": "SRX10768295",
+       "b_cell_00004": "SRX10768294",
+       "t_cell_00001": "SRX12292985",
+       "t_cell_00002": "SRX12292983",
+       "t_cell_00003": "SRX12292984",
+       "t_cell_00004": "SRX12292982",
    }
    ```
 
    The pairs above are "name" and "label" of each methylome for the query. The
    name must be valid, and the label can be anything you choose. The `select`
    command has functions to automatically create a mapping like the one
-   above. The methylomes are not necessarily ordered in this JSON file, but
-   when the query completes, the columns in the output will be sorted by their
-   label. This will also help, for example, color a PCA plot based on parts of
+   above. This will also help, for example, color a PCA plot based on parts of
    the chosen labels. The reason to do this in the query command, and not
    later, is because I often combine these files, and when they get larger
    changing the header can become annoying. So I have the labels inserted as


### PR DESCRIPTION
The order of alt/group names and methylome names has been swapped so it is closer to a group definition, which will be more useful when the same format is incorporated into Rxfr and pyxfr