### PR TITLE
Compressing query response for bins

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -68,6 +68,7 @@ target_link_libraries(transferase_system PUBLIC
   Threads::Threads
   OpenSSL::SSL
   OpenSSL::Crypto
+  deflate
 )
 
 if(TEST_LIB)

--- a/lib/client_connection.hpp
+++ b/lib/client_connection.hpp
@@ -26,13 +26,13 @@
 
 #include "customize_asio.hpp"
 #include "level_container.hpp"
+#include "libdeflate_adapter.hpp"
 #include "logger.hpp"
 #include "query_container.hpp"
 #include "request.hpp"
 #include "response.hpp"
 #include "server_error_code.hpp"
 #include "transfer_stats.hpp"
-#include "zlib_adapter.hpp"
 
 #include <asio.hpp>
 
@@ -74,10 +74,10 @@ public:
   [[nodiscard]] auto
   take_levels() -> level_container<level_t> {
     if (need_decompression() && !status) {
-      const auto p =
-        static_cast<std::uint8_t *>(static_cast<void *>(resp_container.data()));
-      std::vector<std::uint8_t> tmp(p, p + resp_hdr.n_bytes);
-      status = decompress(tmp, resp_container);
+      // NOLINTNEXTLINE (*-reinterpret-cast)
+      const auto buf = reinterpret_cast<std::uint8_t *>(levels_buffer());
+      std::vector<std::uint8_t> tmp(buf, buf + resp_hdr.n_bytes);
+      status = libdeflate_decompress(tmp, resp_container);
     }
     return std::move(resp_container);
   }

--- a/lib/client_connection.hpp
+++ b/lib/client_connection.hpp
@@ -32,6 +32,7 @@
 #include "response.hpp"
 #include "server_error_code.hpp"
 #include "transfer_stats.hpp"
+#include "zlib_adapter.hpp"
 
 #include <asio.hpp>
 
@@ -72,6 +73,12 @@ public:
 
   [[nodiscard]] auto
   take_levels() -> level_container<level_t> {
+    if (need_decompression() && !status) {
+      const auto p =
+        static_cast<std::uint8_t *>(static_cast<void *>(resp_container.data()));
+      std::vector<std::uint8_t> tmp(p, p + resp_hdr.n_bytes);
+      status = decompress(tmp, resp_container);
+    }
     return std::move(resp_container);
   }
 
@@ -134,7 +141,7 @@ public:
     resp_container.resize(resp_hdr.rows, resp_hdr.cols);
     reset_deadline();
     asio::async_read(
-      socket, asio::buffer(levels_buffer(), levels_size()),
+      socket, asio::buffer(levels_buffer(), resp_hdr.n_bytes),
       [this](const auto ec, const auto n_bytes) -> std::size_t {
         reply_stats.update(n_bytes);
         reset_deadline();
@@ -232,6 +239,14 @@ private:
     (void)socket.shutdown(tcp::socket::shutdown_both, unchecked);
     (void)socket.close(unchecked);
     watchdog_timer.cancel();
+  }
+
+  [[nodiscard]] auto
+  need_decompression() const {
+    // resp_hdr.n_bytes: number of bytes transferred; levels_size(): size of
+    // structure computed; levels_size() might be smaller than bytes for
+    // std::size(resp_container)
+    return resp_hdr.n_bytes != levels_size();
   }
 
   [[nodiscard]] auto

--- a/lib/connection.cpp
+++ b/lib/connection.cpp
@@ -105,7 +105,7 @@ connection::read_request() -> void {
 
       if (const auto parse_err = parse(req_buf, req); parse_err) {
         lgr.warning("{} Request parse error: {}", conn_id, parse_err);
-        resp_hdr = {parse_err, 0};
+        resp_hdr = {parse_err, 0, 0, 0};
         respond_with_error();
         return;
       }
@@ -142,7 +142,7 @@ connection::read_query() -> void {
       query_stats.update(n_bytes);
       if (ec) {
         lgr.warning("{} Error reading query: {}", conn_id, ec);
-        resp_hdr = {request_error_code::error_reading_query, 0};
+        resp_hdr = {request_error_code::error_reading_query, 0, 0, 0};
         respond_with_error();
         return;
       }
@@ -202,7 +202,7 @@ connection::respond_with_levels() -> void {
   set_deadline(comm_timeout_sec);
   auto self = shared_from_this();
   asio::async_write(
-    socket, asio::buffer(get_send_buf(), get_response_size()),
+    socket, asio::buffer(get_send_buf(), resp_hdr.n_bytes),
     // completion condition
     [this, self](const auto ec, const auto n_bytes) -> std::size_t {
       reply_stats.update(n_bytes);

--- a/lib/connection.hpp
+++ b/lib/connection.hpp
@@ -83,12 +83,6 @@ struct connection : public std::enable_shared_from_this<connection> {
   }
 
   [[nodiscard]] auto
-  get_response_size() const -> std::uint32_t {
-    return req.is_covered_request() ? resp_cov.get_n_bytes()
-                                    : resp.get_n_bytes();
-  }
-
-  [[nodiscard]] auto
   is_stopped() const -> bool {
     return !socket.is_open();
   }

--- a/lib/libdeflate_adapter.hpp
+++ b/lib/libdeflate_adapter.hpp
@@ -1,0 +1,148 @@
+/* MIT License
+ *
+ * Copyright (c) 2025 Andrew D Smith
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef LIB_LIBDEFLATE_ADAPTER_HPP_
+#define LIB_LIBDEFLATE_ADAPTER_HPP_
+
+#include <libdeflate.h>
+
+#include <cassert>
+#include <cstdint>   // for std::uint8_t
+#include <iterator>  // for std::size
+#include <string>
+#include <system_error>
+#include <type_traits>  // for std::true_type
+#include <utility>      // for std::to_underlying, std::unreachable
+#include <vector>
+
+enum class libdeflate_error_code : std::uint8_t {
+  ok = 0,
+  compression_failed = 1,
+  decompression_failed = 2,
+  bad_data = 3,
+  short_output = 4,
+  unexpected_return_code = 5,
+};
+
+template <>
+struct std::is_error_code_enum<libdeflate_error_code> : public std::true_type {
+};
+
+struct libdeflate_error_category : std::error_category {
+  // clang-format off
+  auto name() const noexcept -> const char * override {return "libdeflate_error_code";}
+  auto message(int code) const -> std::string override {
+    using std::string_literals::operator""s;
+    switch (code) {
+    case 0: return "LIBDEFLATE_SUCCESS"s;
+    case 1: return "LIBDEFLATE_COMPRESSION_FAILED"s;
+    case 2: return "LIBDEFLATE_DECOMPRESSION_FAILED"s;
+    case 3: return "LIBDEFLATE_BAD_DATA"s;
+    case 4: return "LIBDEFLATE_SHORT_OUTPUT"s;
+    case 5: return "unexpected return code from libdeflate"s;
+    }
+    std::unreachable();
+  }
+  // clang-format on
+};
+
+inline std::error_code
+make_error_code(libdeflate_error_code e) {
+  static auto category = libdeflate_error_category{};
+  return std::error_code(std::to_underlying(e), category);
+}
+
+namespace transferase {
+
+template <typename T>
+[[nodiscard]] auto
+libdeflate_compress(const T &in,
+                    std::vector<std::uint8_t> &out) -> std::error_code {
+  static constexpr int compression_level = 1;  // level 1 is fastest
+  auto compressor = libdeflate_alloc_compressor(compression_level);
+  if (!compressor)
+    return libdeflate_error_code::compression_failed;
+
+  const auto input_data = reinterpret_cast<const void *>(in.data());
+  const std::size_t input_size = std::size(in) * sizeof(typename T::value_type);
+
+  // estimate max output size
+  const std::size_t max_compressed_size =
+    libdeflate_deflate_compress_bound(compressor, input_size);
+
+  out.resize(max_compressed_size);
+  const std::size_t actual_compressed_size = libdeflate_deflate_compress(
+    compressor, input_data, input_size, out.data(), max_compressed_size);
+
+  // release the compressor
+  libdeflate_free_compressor(compressor);
+
+  if (actual_compressed_size == 0)
+    return libdeflate_error_code::compression_failed;
+
+  out.resize(actual_compressed_size);
+  return libdeflate_error_code::ok;
+}
+
+template <typename T>
+[[nodiscard]] static inline auto
+libdeflate_decompress(std::vector<std::uint8_t> &in,
+                      T &out) -> std::error_code {
+  auto decompressor = libdeflate_alloc_decompressor();
+  if (!decompressor)
+    return libdeflate_error_code::decompression_failed;
+
+  auto out_buf = reinterpret_cast<void *>(out.data());
+  const std::size_t out_size = std::size(out) * sizeof(typename T::value_type);
+
+  // clang-format off
+  const libdeflate_result result = libdeflate_deflate_decompress(
+    decompressor,
+    in.data(),
+    std::size(in),
+    out_buf,
+    out_size,
+    nullptr  // don't care about actual output size
+  );
+  // clang-format on
+
+  libdeflate_free_decompressor(decompressor);
+
+  switch (result) {
+  case LIBDEFLATE_SUCCESS:
+    return libdeflate_error_code::ok;
+  case LIBDEFLATE_BAD_DATA:
+    return libdeflate_error_code::bad_data;
+  case LIBDEFLATE_SHORT_OUTPUT:
+    return libdeflate_error_code::short_output;
+  case LIBDEFLATE_INSUFFICIENT_SPACE:
+    return libdeflate_error_code::decompression_failed;
+  default:
+    assert(false && "Unknown libdeflate result");
+    return libdeflate_error_code::decompression_failed;
+  }
+}
+
+}  // namespace transferase
+
+#endif  // LIB_LIBDEFLATE_ADAPTER_HPP_

--- a/lib/request_handler.cpp
+++ b/lib/request_handler.cpp
@@ -35,6 +35,8 @@
 #include "response.hpp"
 #include "server_error_code.hpp"
 
+#include <cstring>
+#include <iterator>
 #include <memory>  // for std::shared_ptr
 #include <string>
 #include <system_error>

--- a/lib/request_handler.cpp
+++ b/lib/request_handler.cpp
@@ -40,8 +40,6 @@
 #include <system_error>
 #include <vector>
 
-static constexpr bool compress_levels{true};
-
 namespace transferase {
 
 auto
@@ -216,7 +214,7 @@ request_handler::bins_get_levels<level_element_t>(
     meth->get_levels<level_element_t>(req.bin_size(), *index, col_itr);
   }
   resp_hdr.n_bytes = sizeof(level_element_t) * resp_hdr.rows * resp_hdr.cols;
-  if (compress_levels) {
+  if (compress_bins_levels) {
     std::vector<std::uint8_t> tmp;
     const auto compress_err = libdeflate_compress(resp_data.v, tmp);
     if (compress_err)
@@ -269,7 +267,7 @@ request_handler::bins_get_levels<level_element_covered_t>(
     meth->get_levels<level_element_covered_t>(req.bin_size(), *index, col_itr);
   }
   resp_hdr.n_bytes = sizeof(level_element_t) * resp_hdr.rows * resp_hdr.cols;
-  if (compress_levels) {
+  if (compress_bins_levels) {
     std::vector<std::uint8_t> tmp;
     const auto compress_err = libdeflate_compress(resp_data.v, tmp);
     if (compress_err)

--- a/lib/request_handler.hpp
+++ b/lib/request_handler.hpp
@@ -81,6 +81,7 @@ struct request_handler {
   std::string index_file_dir;
   methylome_set methylomes;
   genome_index_set indexes;
+  bool compress_bins_levels{true};
 };
 
 }  // namespace transferase

--- a/lib/response.hpp
+++ b/lib/response.hpp
@@ -45,6 +45,7 @@ struct response_header {
   std::error_code status{};
   std::uint32_t cols{};
   std::uint32_t rows{};
+  std::uint32_t n_bytes{};
   [[nodiscard]] auto
   error() const noexcept -> bool {
     return (status) ? true : false;


### PR DESCRIPTION
This is using libdeflate and happens before sending data back to the client. It might not be the best case for local servers, and it has controlling instance variable for request_handler